### PR TITLE
Optionally ignore test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,11 @@
                             <properties>
                                 <property>
                                     <name>listener</name>
-                                    <value>au.gov.ga.geodesy.support.testng.TestSuiteListener,au.gov.ga.geodesy.support.testng.TestListener</value>
+                                    <value>
+                                        au.gov.ga.geodesy.support.testng.TestSuiteListener,
+                                        au.gov.ga.geodesy.support.testng.TestListener,
+                                        au.gov.ga.geodesy.support.testng.TestDependencyController
+                                    </value>
                                 </property>
                             </properties>
                         </configuration>

--- a/src/test/java/au/gov/ga/geodesy/support/testng/TestDependencyController.java
+++ b/src/test/java/au/gov/ga/geodesy/support/testng/TestDependencyController.java
@@ -1,0 +1,26 @@
+package au.gov.ga.geodesy.support.testng;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.testng.IAnnotationTransformer;
+import org.testng.annotations.ITestAnnotation;
+
+public class TestDependencyController implements IAnnotationTransformer {
+
+    @SuppressWarnings("rawtypes")
+    public void transform(ITestAnnotation annotation, Class testClass, Constructor testConstructor,
+            Method testMethod) {
+
+        if (shouldIgnoreDependencies()) {
+            annotation.setDependsOnMethods(null);
+            annotation.setDependsOnGroups(null);
+        }
+    }
+
+    private boolean shouldIgnoreDependencies() {
+        // TODO: compare to yes or no
+        return System.getProperty("ignoreDependencies") != null;
+    }
+}
+


### PR DESCRIPTION
This is useful when running a single test method, e.g.,

mvn test -Dtest=SiteRepositoryTest#saveAllSiteLogs