### PR TITLE
Prevent annoying context switch on MacOSX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,8 @@
                                     </value>
                                 </property>
                             </properties>
+                            <!-- prevent the annoying ForkedBooter process from stealing window focus on Mac OS -->
+                            <argLine>-Djava.awt.headless=true</argLine>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
* Caused when surefire runs and on the Mac it has
an App 'ForkedBooter' that is associated with it
* See https://somethingididnotknow.wordpress.com/2014/07/23/forkedbooter-steals-window-focus-on-mac-os-while-maven-is-running/