### PR TITLE
Add String to Double converter

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/StringBigDecimalConverter.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/StringBigDecimalConverter.java
@@ -1,0 +1,41 @@
+package au.gov.ga.geodesy.support.mapper.dozer;
+
+import java.math.BigDecimal;
+
+import org.dozer.CustomConverter;
+import org.dozer.MappingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.opengis.iso19139.gco.v_20070417.CharacterStringPropertyType;
+
+/**
+ * Convert: java.lang.String <--> java.math.BigDecimal
+ * 
+ * A recent change was to make the type of an element Doouble instead of String. JaxB's xjc is turning some of those into BigDecimals
+ * instead. Manage possible problem values.
+ * 
+ */
+public class StringBigDecimalConverter implements CustomConverter {
+    Logger logger = LoggerFactory.getLogger(getClass());
+
+    @SuppressWarnings("rawtypes")
+    public Object convert(Object destination, Object source, Class destClass, Class sourceClass) {
+        if (source == null) {
+            return null;
+        }
+        if (source instanceof String) {
+            // use the String <--> Double converter
+            Double doubleVal = DozerDelegate.mapWithGuard((String) source, Double.class);
+
+            BigDecimal dest = BigDecimal.valueOf(doubleVal);
+            return dest;
+        } else if (source instanceof BigDecimal) {
+            BigDecimal sourceType = (BigDecimal) source;
+            return new Double(sourceType.doubleValue()).toString();
+        } else {
+            throw new MappingException("Converter TestCustomConverter " + "used incorrectly. Arguments passed in were:"
+                    + destination + " and " + source);
+        }
+    }
+}

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/StringDoubleConverter.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/StringDoubleConverter.java
@@ -1,0 +1,75 @@
+package au.gov.ga.geodesy.support.mapper.dozer;
+
+import org.dozer.CustomConverter;
+import org.dozer.MappingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Convert: java.lang.String <--> java.lang.Double
+ * 
+ * A recent change was to make the type of an element Double instead of String. Manage possible problem values.
+ * 
+ */
+public class StringDoubleConverter implements CustomConverter {
+    Logger logger = LoggerFactory.getLogger(getClass());
+
+    @SuppressWarnings("rawtypes")
+    public Object convert(Object destination, Object source, Class destClass, Class sourceClass) {
+        if (source == null) {
+            return null;
+        }
+        if (source instanceof String) {
+            Double dest = null;
+            try {
+                dest = Double.parseDouble((String) source);
+            } catch (NumberFormatException e) {
+                dest = Double.parseDouble(handleProblemValues((String) source));
+            }
+            return dest;
+        } else if (source instanceof Double) {
+            Double sourceType = (Double) source;
+            return sourceType.toString();
+        } else {
+            throw new MappingException("Converter TestCustomConverter " + "used incorrectly. Arguments passed in were:"
+                    + destination + " and " + source);
+        }
+    }
+
+    /**
+     * Deal with possible problem Strings, returning a Double equivalent or 0.0.
+     * 
+     * @param source
+     *            to find alt Double-like value
+     * @return Double equivalent of given String or 0.0
+     */
+    private String handleProblemValues(String source) {
+        switch (source.toUpperCase()) {
+        case "NONE":
+            return "0.0";
+        }
+        // drop "+-" or "-+"
+        String dropPlusMinux = source.replaceAll("\\+-|-\\+", "");
+        // drop % relative humidity
+        String dropRelH = dropPlusMinux.toUpperCase().replaceAll("\\% REL H", "");
+        // drop any units suffix
+        String dropUnits = dropRelH.toUpperCase().replaceAll("[A-Z]+\\W*[A-Z]*$", "");
+        String finaldropUnits = dropUnits.length() > 0 ? dropUnits : "0.0";
+
+        // If there are any non-digit chars left then the input was BAD. To allow translate to go through drop everything else and log an
+        // ERRORÏ
+        String finalResult = null;
+
+        if (finaldropUnits.toUpperCase().matches("[\\W\\d]*[A-Z]+.*")) {
+            logger.error("source cannot be made purely numeric - fix source data: " + source);
+            finalResult = finaldropUnits.toUpperCase().replaceAll("[A-Z\\W]", "");
+        } else {
+            finalResult = finaldropUnits;
+        }
+        String superFinalResult = finalResult.length() > 0 ? finalResult : "0.0";
+
+        logger.debug("handleProblemValues - input: " + source + ", output: " + superFinalResult);
+        return superFinalResult;
+    }
+
+}

--- a/src/main/resources/dozer/ConverterMappings.xml
+++ b/src/main/resources/dozer/ConverterMappings.xml
@@ -49,6 +49,14 @@
                 <class-a>au.gov.ga.geodesy.igssitelog.domain.model.Agency</class-a>
                 <class-b>au.gov.xml.icsm.geodesyml.v_0_3.AgencyPropertyType</class-b>
             </converter>
+            <converter type="au.gov.ga.geodesy.support.mapper.dozer.StringDoubleConverter">
+                <class-a>java.lang.String</class-a>
+                <class-b>java.lang.Double</class-b>
+            </converter>
+            <converter type="au.gov.ga.geodesy.support.mapper.dozer.StringBigDecimalConverter">
+                <class-a>java.lang.String</class-a>
+                <class-b>java.math.BigDecimal</class-b>
+            </converter>
         </custom-converters>
     </configuration>
 </mappings>

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/StringDoubleConverterTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/StringDoubleConverterTest.java
@@ -1,0 +1,89 @@
+package au.gov.ga.geodesy.support.mapper.dozer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringDoubleConverterTest {
+    StringDoubleConverter conv = new StringDoubleConverter();
+
+    @Test
+    public void test01() {
+        Double dest = null;
+        String source = "none";
+        
+        dest = (Double) conv.convert(dest, source, Double.class, String.class);
+        
+        Assert.assertEquals(0.0, dest, 0.01);
+    }
+
+    @Test
+    public void test02() {
+        Double dest = null;
+        String source = "+1mm";
+        
+        dest = (Double) conv.convert(dest, source, Double.class, String.class);
+        
+        Assert.assertEquals(1.0, dest, 0.01);
+    }
+
+    @Test
+    public void test03() {
+        Double dest = null;
+        String source = "-1mm";
+        
+        dest = (Double) conv.convert(dest, source, Double.class, String.class);
+        
+        Assert.assertEquals(-1.0, dest, 0.01);
+    }
+
+    @Test
+    public void test04() {
+        Double dest = null;
+        String source = "+-1mm";
+        
+        dest = (Double) conv.convert(dest, source, Double.class, String.class);
+        
+        Assert.assertEquals(1.0, dest, 0.01);
+    }
+
+    @Test
+    public void test05() {
+        Double dest = null;
+        String source = "2% rel h";
+        
+        dest = (Double) conv.convert(dest, source, Double.class, String.class);
+        
+        Assert.assertEquals(2.0, dest, 0.01);
+    }
+    @Test
+    public void test06() {
+        Double dest = null;
+        String source = "0.5 deg C";
+        
+        dest = (Double) conv.convert(dest, source, Double.class, String.class);
+        
+        Assert.assertEquals(0.5, dest, 0.01);
+    }
+    @Test
+    public void test07() {
+        Double dest = null;
+     // Yep great number this one!  Found in MAT1.xml
+        String source = "20B0C +-5B0C";
+        
+        dest = (Double) conv.convert(dest, source, Double.class, String.class);
+        
+        Assert.assertEquals(20050, dest, 0.01);
+    }
+
+    @Test
+    public void test08() {
+        Double dest = null;
+        // Yep great number this one!  Found in MAT1.xml
+        String source = "Input Frequency        ";
+        
+        dest = (Double) conv.convert(dest, source, Double.class, String.class);
+        
+        Assert.assertEquals(0.0, dest, 0.01);
+    }
+
+}

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/TranslateTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/TranslateTest.java
@@ -184,10 +184,10 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(receiver1.getSatelliteSystem().get(0).getValue(), "GPS");
         Assert.assertEquals(receiver1.getSerialNumber(), "C128");
         Assert.assertEquals(receiver1.getFirmwareVersion(), "3.2.32.9");
-        Assert.assertEquals(receiver1.getElevationCutoffSetting(), "0");
+        Assert.assertEquals(receiver1.getElevationCutoffSetting(), 0, 0.01);
         Assert.assertEquals(receiver1.getDateInstalled().getValue().get(0), "31 Jul 1999 01:00 GMT");
         Assert.assertEquals(receiver1.getDateRemoved().getValue().get(0), "14 Jan 2000 01:50 GMT");
-        Assert.assertEquals(receiver1.getTemperatureStabilization(), "none");
+        Assert.assertEquals(receiver1.getTemperatureStabilization(), 0, 0.01);
         Assert.assertEquals(receiver1.getNotes(), "Upgrade of firmware to avoid GPS week");
 
         // Antennas
@@ -201,10 +201,10 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(antenna1.getAntennaType().getValue(), "AOAD/M_T AUST");
         Assert.assertEquals(antenna1.getSerialNumber(), "318");
         Assert.assertEquals(antenna1.getAntennaReferencePoint().getValue(), "BPA");
-        Assert.assertEquals(antenna1.getMarkerArpUpEcc(), "0.007");
-        Assert.assertEquals(antenna1.getMarkerArpNorthEcc(), "0.0");
-        Assert.assertEquals(antenna1.getMarkerArpEastEcc(), "0.0");
-        Assert.assertEquals(antenna1.getAlignmentFromTrueNorth(), "0");
+        Assert.assertEquals(antenna1.getMarkerArpUpEcc(), 0.007, 0.00001);
+        Assert.assertEquals(antenna1.getMarkerArpNorthEcc(), 0.0, 0.01);
+        Assert.assertEquals(antenna1.getMarkerArpEastEcc(), 0.0, 0.01);
+        Assert.assertEquals(antenna1.getAlignmentFromTrueNorth(), 0.0, 0.01);
         Assert.assertEquals(antenna1.getAntennaRadomeType().getValue(), "AUST");
         Assert.assertEquals(antenna1.getDateInstalled().getValue().get(0), "15 May 1994 00:00 GMT");
         Assert.assertEquals(antenna1.getDateRemoved().getValue().get(0), "15 Jun 2003 03:30 GMT");
@@ -220,10 +220,10 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         SurveyedLocalTiesType surveyedTies1 = surveyedLocalTies.get(0).getSurveyedLocalTies();
         // Test some required fields
         Assert.assertEquals(surveyedTies1.getTiedMarkerName(), "RM1");
-        Assert.assertEquals(surveyedTies1.getDifferentialComponentsGNSSMarkerToTiedMonumentITRS().getDx(), "-15.366");
-        Assert.assertEquals(surveyedTies1.getDifferentialComponentsGNSSMarkerToTiedMonumentITRS().getDy(), "-9.632");
-        Assert.assertEquals(surveyedTies1.getDifferentialComponentsGNSSMarkerToTiedMonumentITRS().getDz(), "9.099");
-        Assert.assertEquals(surveyedTies1.getLocalSiteTiesAccuracy(), "+-1mm");
+        Assert.assertEquals(surveyedTies1.getDifferentialComponentsGNSSMarkerToTiedMonumentITRS().getDx(), -15.366, 0.0001);
+        Assert.assertEquals(surveyedTies1.getDifferentialComponentsGNSSMarkerToTiedMonumentITRS().getDy(), -9.632, 0.0001);
+        Assert.assertEquals(surveyedTies1.getDifferentialComponentsGNSSMarkerToTiedMonumentITRS().getDz(), 9.09, 0.01);
+        Assert.assertEquals(surveyedTies1.getLocalSiteTiesAccuracy(), 1.0, 0.01);
         Assert.assertEquals(surveyedTies1.getDateMeasured().getValue().get(0), "11 Aug 1992 14:00 GMT");
 
         // FrequencyStandardPropertyType
@@ -251,9 +251,9 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
                         .getTheTimePeriodType(humiditySensor.getValidTime()).getBeginPosition().getValue().get(0)),
                 "29 Mar 2006 00:00 GMT");
         Assert.assertEquals(humiditySensor.getSerialNumber(), "98850");
-        Assert.assertEquals(humiditySensor.getHeightDiffToAntenna(), "2.4");
-        Assert.assertEquals(humiditySensor.getDataSamplingInterval(), "30");
-        Assert.assertEquals(humiditySensor.getAccuracyPercentRelativeHumidity(), "2% rel h");
+        Assert.assertEquals(humiditySensor.getHeightDiffToAntenna(), 2.4, 0.001);
+        Assert.assertEquals(humiditySensor.getDataSamplingInterval(), 30, 0.01);
+        Assert.assertEquals(humiditySensor.getAccuracyPercentRelativeHumidity(), 2.0, 0.001);
         Assert.assertEquals(humiditySensor.getAspiration(), "FAN");
 
         // Pressuer Sensors
@@ -270,9 +270,9 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
                 "29 Mar 2006 00:00 GMT");
         Assert.assertEquals(pressureSensor.getManufacturer(), "Paroscientific, Inc.");
         Assert.assertEquals(pressureSensor.getSerialNumber(), "98850");
-        Assert.assertEquals(pressureSensor.getHeightDiffToAntenna(), "2.4");
-        Assert.assertEquals(pressureSensor.getDataSamplingInterval(), "30");
-        Assert.assertEquals(pressureSensor.getAccuracyHPa(), "0.1 mbar");
+        Assert.assertEquals(pressureSensor.getHeightDiffToAntenna(), 2.4, 0.01);
+        Assert.assertEquals(pressureSensor.getDataSamplingInterval(), 30, 0.01);
+        Assert.assertEquals(pressureSensor.getAccuracyHPa(), 0.1, 0.001);
 
         // Water Vapour Sensors
         List<WaterVaporSensorPropertyType> waterVapourSensors = siteLogType
@@ -300,9 +300,9 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
                         .getTheTimePeriodType(temperatureSensor.getValidTime()).getBeginPosition().getValue().get(0)),
                 "29 Mar 2006 00:00 GMT");
         Assert.assertEquals(temperatureSensor.getSerialNumber(), "98850");
-        Assert.assertEquals(temperatureSensor.getHeightDiffToAntenna(), "2.4");
-        Assert.assertEquals(temperatureSensor.getDataSamplingInterval(), "30");
-        Assert.assertEquals(temperatureSensor.getAccuracyDegreesCelcius(), "0.5 deg C");
+        Assert.assertEquals(temperatureSensor.getHeightDiffToAntenna(), 2.4, 0.001);
+        Assert.assertEquals(temperatureSensor.getDataSamplingInterval().doubleValue(), 30, 0.001);
+        Assert.assertEquals(temperatureSensor.getAccuracyDegreesCelcius().doubleValue(), 0.5, 0.001);
         Assert.assertEquals(temperatureSensor.getAspiration(), "FAN");
 
         // Local Episodic Events


### PR DESCRIPTION
* Needed due to a recent change was to make the type of an element Double
instead of String for various elements. Manage possible problem
values.
* JAXB xjc converts Double to either Double or BigInteger and so I've
created converters for both cases (the latter using the former)