### PR TITLE
Sort out serial numbers

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/populator/GnssAntennaTypePopulator.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/populator/GnssAntennaTypePopulator.java
@@ -15,7 +15,7 @@ public class GnssAntennaTypePopulator extends GeodesyMLElementPopulator<GnssAnte
     /**
      * Consider all required elements for this type and add any missing ones with default values.
      * 
-     * @param gnssReceiverType
+     * @param gnssAntennaType
      */
     void checkAllRequiredElementsPopulated(GnssAntennaType gnssAntennaType) {
         // This can be blank when receiver hasn't been removed. Some other logic in the project
@@ -23,5 +23,16 @@ public class GnssAntennaTypePopulator extends GeodesyMLElementPopulator<GnssAnte
         checkElementPopulated(gnssAntennaType, "antennaCableType", GMLMiscTools.getEmptyString());
         checkElementPopulated(gnssAntennaType, "radomeSerialNumber", GMLMiscTools.getEmptyString());
         checkElementPopulated(gnssAntennaType, "dateRemoved", GMLGmlTools.getEmptyTimePositionType());
+        
+        // gnssAntennaType has a SerialNumber (defined on it) and a manufacturerModel (defined on BaseGeodeticEquipmentType, which is the
+        // Grandparent of) and we are uncertain exactly how to handle this multiplicity of what seems to be an element with the same
+        // purpose. For the mean time we will have both elements. This code will make sure of this requirement.
+        if (gnssAntennaType.getManufacturerSerialNumber() == null) {
+            if (gnssAntennaType.getSerialNumber() == null) {
+                checkElementPopulated(gnssAntennaType, "serialNumber", GMLMiscTools.getEmptyString());
+            }
+            checkElementPopulated(gnssAntennaType, "manufacturerSerialNumber", gnssAntennaType.getSerialNumber());
+        }
+        checkElementPopulated(gnssAntennaType, "serialNumber", gnssAntennaType.getManufacturerSerialNumber());
     }
 }

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/populator/GnssReceiverTypePopulator.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/populator/GnssReceiverTypePopulator.java
@@ -1,10 +1,8 @@
 package au.gov.ga.geodesy.support.mapper.dozer.populator;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import au.gov.ga.geodesy.support.utils.GMLGmlTools;
+import au.gov.ga.geodesy.support.utils.GMLMiscTools;
 import au.gov.xml.icsm.geodesyml.v_0_3.GnssReceiverType;
-import net.opengis.gml.v_3_2_1.TimePositionType;
 
 /**
  * The receivers have required elements that don't all exist in the SOPAC Sitelog xml. This fills them in.
@@ -24,13 +22,18 @@ public class GnssReceiverTypePopulator extends GeodesyMLElementPopulator<GnssRec
     public void checkAllRequiredElementsPopulated(GnssReceiverType gnssReceiverType) {
         // This element can be blank when receiver hasn't been removed. Some other logic in the project
         // removes empty elements from the Sopac SiteLog before it gets to this translator
-        checkElementPopulated(gnssReceiverType, "dateRemoved", getBlankTimePositionType());
-    }
+        checkElementPopulated(gnssReceiverType, "dateRemoved", GMLGmlTools.getEmptyTimePositionType());
 
-    private TimePositionType getBlankTimePositionType() {
-        TimePositionType tpt = new TimePositionType();
-        tpt.setValue((List<String>) new ArrayList<String>());
-        return tpt;
-    }
+        // GnssReceiverType has a SerialNumber (defined on it) and a manufacturerModel (defined on BaseGeodeticEquipmentType, which is the
+        // Grandparent of) and we are uncertain exactly how to handle this multiplicity of what seems to be an element with the same
+        // purpose. For the mean time we will have both elements. This code will make sure of this requirement.
+        if (gnssReceiverType.getManufacturerSerialNumber() == null) {
+            if (gnssReceiverType.getSerialNumber() == null) {
+                checkElementPopulated(gnssReceiverType, "serialNumber", GMLMiscTools.getEmptyString());
+            }
+            checkElementPopulated(gnssReceiverType, "manufacturerSerialNumber", gnssReceiverType.getSerialNumber());
+        }
+        checkElementPopulated(gnssReceiverType, "serialNumber", gnssReceiverType.getManufacturerSerialNumber());
 
+    }
 }

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/populator/GnssReceiverTypePopulatorTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/populator/GnssReceiverTypePopulatorTest.java
@@ -1,0 +1,75 @@
+package au.gov.ga.geodesy.support.mapper.dozer.populator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import au.gov.xml.icsm.geodesyml.v_0_3.GnssReceiverType;
+
+public class GnssReceiverTypePopulatorTest {
+    private static final GnssReceiverTypePopulator gnssReceiverTypePopulator = new GnssReceiverTypePopulator();
+
+    private static final String SERIAL_NO = "serialNo";
+    private static final String MAN_SERIAL_NO = "manSerialNo";
+    private static final String EMPTY = "";
+
+    @Test
+    public void testSerialYesManufacturerSerialYes() {
+        GnssReceiverType gnssReceiverType = new GnssReceiverType();
+
+        gnssReceiverType.setSerialNumber(SERIAL_NO);
+        gnssReceiverType.setManufacturerSerialNumber(MAN_SERIAL_NO);
+
+        gnssReceiverTypePopulator.checkAllRequiredElementsPopulated(gnssReceiverType);
+
+        Assert.assertNotNull(gnssReceiverType.getSerialNumber());
+        Assert.assertNotNull(gnssReceiverType.getManufacturerSerialNumber());
+        Assert.assertEquals(SERIAL_NO, gnssReceiverType.getSerialNumber());
+        Assert.assertEquals(MAN_SERIAL_NO, gnssReceiverType.getManufacturerSerialNumber());
+    }
+
+    @Test
+    public void testSerialYesManufacturerSerialNo() {
+        GnssReceiverType gnssReceiverType = new GnssReceiverType();
+
+        gnssReceiverType.setSerialNumber(SERIAL_NO);
+        // gnssReceiverType.setManufacturerSerialNumber(MAN_SERIAL_NO);
+
+        gnssReceiverTypePopulator.checkAllRequiredElementsPopulated(gnssReceiverType);
+
+        Assert.assertNotNull(gnssReceiverType.getSerialNumber());
+        Assert.assertNotNull(gnssReceiverType.getManufacturerSerialNumber());
+        Assert.assertEquals(SERIAL_NO, gnssReceiverType.getSerialNumber());
+        Assert.assertEquals(SERIAL_NO, gnssReceiverType.getManufacturerSerialNumber());
+    }
+
+    @Test
+    public void testSerialNoManufacturerSerialYes() {
+        GnssReceiverType gnssReceiverType = new GnssReceiverType();
+
+        // gnssReceiverType.setSerialNumber(SERIAL_NO);
+        gnssReceiverType.setManufacturerSerialNumber(MAN_SERIAL_NO);
+
+        gnssReceiverTypePopulator.checkAllRequiredElementsPopulated(gnssReceiverType);
+
+        Assert.assertNotNull(gnssReceiverType.getSerialNumber());
+        Assert.assertNotNull(gnssReceiverType.getManufacturerSerialNumber());
+        Assert.assertEquals(MAN_SERIAL_NO, gnssReceiverType.getSerialNumber());
+        Assert.assertEquals(MAN_SERIAL_NO, gnssReceiverType.getManufacturerSerialNumber());
+    }
+
+    @Test
+    public void testSerialNoManufacturerSerialNo() {
+        GnssReceiverType gnssReceiverType = new GnssReceiverType();
+
+        // gnssReceiverType.setSerialNumber(SERIAL_NO);
+        // gnssReceiverType.setManufacturerSerialNumber(MAN_SERIAL_NO);
+
+        gnssReceiverTypePopulator.checkAllRequiredElementsPopulated(gnssReceiverType);
+
+        Assert.assertNotNull(gnssReceiverType.getSerialNumber());
+        Assert.assertNotNull(gnssReceiverType.getManufacturerSerialNumber());
+        Assert.assertEquals(EMPTY, gnssReceiverType.getSerialNumber());
+        Assert.assertEquals(EMPTY, gnssReceiverType.getManufacturerSerialNumber());
+    }
+
+}


### PR DESCRIPTION
GnssReceiverType and GnssAntennaType have a SerialNumber (defined on it) and a manufacturerModel (defined on BaseGeodeticEquipmentType, which is the Grandparent of those).  We are uncertain exactly how to handle this multiplicity of what seems to be an element with the same purpose. For the mean time we will have both elements. This code will make sure of this requirement. It will make an empty one the same as the other or "" if neither is defined.