### PR TITLE
Manage when Sopac's MoreInformation doesnt exist

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/GeodesyMLSiteLogDozerTranslator.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/GeodesyMLSiteLogDozerTranslator.java
@@ -187,6 +187,10 @@ public class GeodesyMLSiteLogDozerTranslator implements GeodesyMLSiteLogTranslat
         MoreInformation moreInformation = sopacSiteLog.getMoreInformation();
         MoreInformationType moreInformationType = DozerDelegate.mapWithGuardWithDecorators(moreInformation,
                 MoreInformationType.class);
+        // Construct an empty instance if Sopac's moreInformation is empty (null) and thus moreInformationType is also from translate
+        if (moreInformationType == null) {
+            moreInformationType = new MoreInformationType();
+        }
         MoreInformationAfterMapping.fixMoreInformation(moreInformation, moreInformationType);
         siteLogType.setMoreInformation(moreInformationType);
 

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/MoreInformationAfterMapping.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/MoreInformationAfterMapping.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.commons.lang.StringUtils;
 
 import au.gov.ga.geodesy.igssitelog.domain.model.MoreInformation;
+import au.gov.ga.geodesy.support.mapper.dozer.populator.MoreInformationTypePopulator;
 import au.gov.ga.geodesy.support.utils.GMLMiscTools;
 import au.gov.xml.icsm.geodesyml.v_0_3.MoreInformationType;
 
@@ -21,11 +22,20 @@ import au.gov.xml.icsm.geodesyml.v_0_3.MoreInformationType;
  *
  */
 public class MoreInformationAfterMapping {
-
     public static void fixMoreInformation(MoreInformation moreInformation, MoreInformationType moreInformationType) {
         List<String> dataCenters = GMLMiscTools.getEmptyList(String.class);
-        String primary = moreInformation.getPrimaryDataCenter();
-        String secondary = moreInformation.getSecondaryDataCenter();
+        String primary = null;
+        String secondary = null;
+        // Sopac's moreInformation can be empty (null).  However it is expected that the  MoreInformationType has been created
+        if (moreInformation == null) {
+            MoreInformationTypePopulator moreInformationTypePopulator = new MoreInformationTypePopulator();
+            moreInformationTypePopulator.checkAllRequiredElementsPopulated(moreInformationType);
+            primary = "";
+            secondary = "";
+        } else {
+            primary = moreInformation.getPrimaryDataCenter();
+            secondary = moreInformation.getSecondaryDataCenter();
+        }
         dataCenters.add(StringUtils.isBlank(primary) ? "" : primary);
         if (StringUtils.isBlank(secondary)) {
             // nothing
@@ -34,5 +44,4 @@ public class MoreInformationAfterMapping {
         }
         moreInformationType.setDataCenter(dataCenters);
     }
-
 }

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/converter/MoreInformationAfterMappingTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/converter/MoreInformationAfterMappingTest.java
@@ -1,0 +1,27 @@
+package au.gov.ga.geodesy.support.mapper.dozer.converter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import au.gov.ga.geodesy.igssitelog.domain.model.MoreInformation;
+import au.gov.xml.icsm.geodesyml.v_0_3.MoreInformationType;
+
+public class MoreInformationAfterMappingTest {
+    @Test
+    public void testMoreInformationIsNull() {
+        MoreInformation moreInformation = null;
+        MoreInformationType moreInformationType = new MoreInformationType();
+        MoreInformationAfterMapping.fixMoreInformation(moreInformation, moreInformationType);
+
+        Assert.assertNotNull(moreInformationType.getDataCenter());
+        Assert.assertEquals(1, moreInformationType.getDataCenter().size());
+        Assert.assertEquals("", moreInformationType.getDataCenter().get(0));
+
+        Assert.assertNotNull(moreInformationType.getUrlForMoreInformation());
+        Assert.assertNotNull(moreInformationType.getSiteMap());
+        Assert.assertNotNull(moreInformationType.getMonumentDescription());
+        Assert.assertNotNull(moreInformationType.getAntennaGraphicsWithDimensions());
+        Assert.assertNotNull(moreInformationType.getInsertTextGraphicFromAntenna());
+    }
+
+}


### PR DESCRIPTION
* Due to validation and schema need one in GeodesyML
* Create a MoreInformationType and populate with defaults