### PR TITLE
Simplify test dependencies

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/domain/service/CorsSiteService.java
+++ b/src/main/java/au/gov/ga/geodesy/domain/service/CorsSiteService.java
@@ -41,7 +41,7 @@ import au.gov.ga.geodesy.domain.model.sitelog.EquipmentLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.SiteLog;
 import au.gov.ga.geodesy.domain.model.sitelog.SiteIdentification;
 
-@Component
+@Component("CorsSiteService")
 @Transactional("geodesyTransactionManager")
 public class CorsSiteService implements EventSubscriber<SiteLogReceived> {
 

--- a/src/main/java/au/gov/ga/geodesy/domain/service/NodeService.java
+++ b/src/main/java/au/gov/ga/geodesy/domain/service/NodeService.java
@@ -42,7 +42,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 
-@Component
+@Component("NodeService")
 @Transactional("geodesyTransactionManager")
 public class NodeService implements EventSubscriber<SiteUpdated> {
 

--- a/src/main/java/au/gov/ga/geodesy/port/SiteLogReader.java
+++ b/src/main/java/au/gov/ga/geodesy/port/SiteLogReader.java
@@ -2,11 +2,21 @@ package au.gov.ga.geodesy.port;
 
 import java.io.Reader;
 
+import au.gov.ga.geodesy.exception.GeodesyRuntimeException;
+
 public abstract class SiteLogReader implements SiteLogSource {
 
-    protected Reader input;
+    private Reader input;
 
-    public SiteLogReader(Reader input) {
+    public void setSiteLogReader(Reader input) {
         this.input = input;
+    }
+    
+    
+    public Reader getSiteLogReader() {
+        if (input == null) {
+            throw new GeodesyRuntimeException("SiteLogReader must be set first!");
+        }
+        return input;
     }
 }

--- a/src/main/java/au/gov/ga/geodesy/port/adapter/rest/SiteLogEndpoint.java
+++ b/src/main/java/au/gov/ga/geodesy/port/adapter/rest/SiteLogEndpoint.java
@@ -20,7 +20,6 @@ import au.gov.ga.geodesy.domain.service.IgsSiteLogService;
 import au.gov.ga.geodesy.port.InvalidSiteLogException;
 import au.gov.ga.geodesy.port.SiteLogReader;
 import au.gov.ga.geodesy.port.adapter.geodesyml.GeodesyMLValidator;
-import au.gov.ga.geodesy.port.adapter.sopac.SiteLogSopacReader;
 import au.gov.ga.xmlschemer.Violation;
 
 @Controller
@@ -36,6 +35,9 @@ public class SiteLogEndpoint {
     @Autowired
     private GeodesyMLValidator geodesyMLValidator;
 
+    @Autowired
+    private SiteLogReader siteLogSource;
+
     @RequestMapping(value = "/validate", method = RequestMethod.POST)
     public ResponseEntity<List<Violation>> validate(HttpServletRequest req, HttpServletResponse rsp) throws IOException {
         StreamSource source = new StreamSource(req.getInputStream(), "data:");
@@ -49,11 +51,10 @@ public class SiteLogEndpoint {
 
     @RequestMapping(value = "/sopac/upload", method = RequestMethod.POST)
     public void upload(HttpServletRequest req, HttpServletResponse rsp) throws IOException {
-        SiteLogReader reader = new SiteLogSopacReader(new InputStreamReader(req.getInputStream()));
+        siteLogSource.setSiteLogReader(new InputStreamReader(req.getInputStream()));
         try {
-            service.upload(reader.getSiteLog());
-        }
-        catch (InvalidSiteLogException e) {
+            service.upload(siteLogSource.getSiteLog());
+        } catch (InvalidSiteLogException e) {
             // TODO
             e.printStackTrace();
         }

--- a/src/main/java/au/gov/ga/geodesy/port/adapter/sopac/SiteLogSopacReader.java
+++ b/src/main/java/au/gov/ga/geodesy/port/adapter/sopac/SiteLogSopacReader.java
@@ -4,6 +4,7 @@ import java.io.Reader;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.stereotype.Component;
 
 import au.gov.ga.geodesy.domain.model.sitelog.SiteLog;
 import au.gov.ga.geodesy.igssitelog.interfaces.xml.IgsSiteLogXmlMarshaller;
@@ -11,6 +12,7 @@ import au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException;
 import au.gov.ga.geodesy.port.InvalidSiteLogException;
 import au.gov.ga.geodesy.port.SiteLogReader;
 
+@Component
 @Configurable(preConstruction = true)
 public class SiteLogSopacReader extends SiteLogReader {
 
@@ -22,18 +24,18 @@ public class SiteLogSopacReader extends SiteLogReader {
     @Autowired
     private SiteLogSopacMapper mapper;
 
-    public SiteLogSopacReader(Reader input) {
-        super(input);
+    public void setSiteLogReader(Reader input) {
+        super.setSiteLogReader(input);
+        this.siteLog = null;
     }
 
     public SiteLog getSiteLog() throws InvalidSiteLogException {
         try {
             if (siteLog == null) {
-                siteLog = mapper.fromDTO(marshaller.unmarshal(input));
+                siteLog = mapper.fromDTO(marshaller.unmarshal(getSiteLogReader()));
             }
             return siteLog;
-        }
-        catch (MarshallingException e) {
+        } catch (MarshallingException e) {
             throw new InvalidSiteLogException(e);
         }
     }

--- a/src/main/java/au/gov/ga/geodesy/support/spring/GeodesySupportConfig.java
+++ b/src/main/java/au/gov/ga/geodesy/support/spring/GeodesySupportConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 
 import au.gov.ga.geodesy.igssitelog.interfaces.xml.IgsSiteLogXmlMarshaller;
 import au.gov.ga.geodesy.igssitelog.support.marshalling.moxy.IgsSiteLogMoxyMarshaller;
@@ -29,5 +30,15 @@ public class GeodesySupportConfig {
 	@Bean
     public IgsSiteLogXmlMarshaller siteLogMarshaller() throws Exception {
         return new IgsSiteLogMoxyMarshaller();
+    }
+
+    /**
+     * @return a PropertySourcesPlaceholderConfigurer for wiring @value ${xxx} resources
+     */
+	@Bean
+    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        PropertySourcesPlaceholderConfigurer p = new PropertySourcesPlaceholderConfigurer();
+
+        return p;
     }
 }

--- a/src/test/java/au/gov/ga/geodesy/domain/model/MockEventPublisher.java
+++ b/src/test/java/au/gov/ga/geodesy/domain/model/MockEventPublisher.java
@@ -4,11 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.springframework.stereotype.Component;
 
 import au.gov.ga.geodesy.domain.model.event.Event;
 import au.gov.ga.geodesy.domain.model.event.EventPublisher;
 import au.gov.ga.geodesy.domain.model.event.EventSubscriber;
 
+@Component
 public class MockEventPublisher implements EventPublisher {
 
     private List<Event> publishedEvents = new ArrayList<>();

--- a/src/test/java/au/gov/ga/geodesy/domain/model/SynchronousEventPublisher.java
+++ b/src/test/java/au/gov/ga/geodesy/domain/model/SynchronousEventPublisher.java
@@ -5,11 +5,13 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import au.gov.ga.geodesy.domain.model.event.Event;
 import au.gov.ga.geodesy.domain.model.event.EventPublisher;
 import au.gov.ga.geodesy.domain.model.event.EventSubscriber;
 
+@Component
 public class SynchronousEventPublisher implements EventPublisher {
 
     private static final Logger log = LoggerFactory.getLogger(SynchronousEventPublisher.class);

--- a/src/test/java/au/gov/ga/geodesy/domain/service/MultipleSitesTest.java
+++ b/src/test/java/au/gov/ga/geodesy/domain/service/MultipleSitesTest.java
@@ -13,52 +13,59 @@ import org.springframework.test.context.testng.AbstractTransactionalTestNGSpring
 import org.springframework.transaction.annotation.Transactional;
 import org.testng.annotations.Test;
 
+import au.gov.ga.geodesy.domain.model.SynchronousEventPublisher;
 import au.gov.ga.geodesy.domain.model.sitelog.SiteLogRepository;
+import au.gov.ga.geodesy.igssitelog.support.marshalling.moxy.IgsSiteLogMoxyMarshaller;
 import au.gov.ga.geodesy.port.InvalidSiteLogException;
-import au.gov.ga.geodesy.port.SiteLogSource;
+import au.gov.ga.geodesy.port.SiteLogReader;
 import au.gov.ga.geodesy.port.adapter.sopac.SiteLogSopacReader;
-import au.gov.ga.geodesy.support.spring.GeodesyServiceTestConfig;
-import au.gov.ga.geodesy.support.spring.GeodesySupportConfig;
+import au.gov.ga.geodesy.support.mapper.orika.SiteLogOrikaMapper;
 import au.gov.ga.geodesy.support.spring.PersistenceJpaConfig;
+import au.gov.ga.geodesy.support.spring.TestAppConfig;
 
-@ContextConfiguration(classes = { GeodesySupportConfig.class, GeodesyServiceTestConfig.class,
-		PersistenceJpaConfig.class }, loader = AnnotationConfigContextLoader.class)
+@ContextConfiguration(classes = {TestAppConfig.class, IgsSiteLogService.class, SiteLogSopacReader.class,
+        SiteLogOrikaMapper.class, IgsSiteLogMoxyMarshaller.class, SynchronousEventPublisher.class,
+        PersistenceJpaConfig.class}, loader = AnnotationConfigContextLoader.class)
 
 @Transactional("geodesyTransactionManager")
 public class MultipleSitesTest extends AbstractTransactionalTestNGSpringContextTests {
 
-	private static final String scenarioDirName = "src/test/resources/multiple-sites/";
+    private static final String scenarioDirName = "src/test/resources/multiple-sites/";
 
-	@Autowired
-	private IgsSiteLogService siteLogService;
+    @Autowired
+    private IgsSiteLogService siteLogService;
 
-	@Autowired
-	private SiteLogRepository siteLogs;
+    @Autowired
+    private SiteLogRepository siteLogs;
 
-	private int numberOfSites;
+    @Autowired
+    private SiteLogReader siteLogSource;
 
-	/**
-	 * Each siteLog file must have a unique getSiteIdentification.
-	 * @param scenarioDirName
-	 * @throws InvalidSiteLogException
-	 * @throws IOException
-	 */
-	private void executeSiteLogScenario(String scenarioDirName) throws IOException, InvalidSiteLogException {
-		File[] siteLogFiles = new File(scenarioDirName).listFiles((File dir, String f) -> {
-			return f.endsWith(".xml");
-		});
-		numberOfSites = siteLogFiles.length;
-		for (File f : siteLogFiles) {
-            SiteLogSource input = new SiteLogSopacReader(new FileReader(f));
-			siteLogService.upload(input.getSiteLog());
-		}
-	}
+    private int numberOfSites;
 
-	@Test
-	@Rollback(false)
-	public void checkSetupId() throws Exception {
-		Assert.assertEquals(0, siteLogs.count());
-		executeSiteLogScenario(scenarioDirName);
-		Assert.assertEquals(numberOfSites, siteLogs.count());
-	}
+    /**
+     * Each siteLog file must have a unique getSiteIdentification.
+     * 
+     * @param scenarioDirName
+     * @throws InvalidSiteLogException
+     * @throws IOException
+     */
+    private void executeSiteLogScenario(String scenarioDirName) throws IOException, InvalidSiteLogException {
+        File[] siteLogFiles = new File(scenarioDirName).listFiles((File dir, String f) -> {
+            return f.endsWith(".xml");
+        });
+        numberOfSites = siteLogFiles.length;
+        for (File f : siteLogFiles) {
+            siteLogSource.setSiteLogReader(new FileReader(f));
+            siteLogService.upload(siteLogSource.getSiteLog());
+        }
+    }
+
+    @Test
+    @Rollback(false)
+    public void checkSetupId() throws Exception {
+        Assert.assertEquals(0, siteLogs.count());
+        executeSiteLogScenario(scenarioDirName);
+        Assert.assertEquals(numberOfSites, siteLogs.count());
+    }
 }

--- a/src/test/java/au/gov/ga/geodesy/port/adapter/rest/RestTest.java
+++ b/src/test/java/au/gov/ga/geodesy/port/adapter/rest/RestTest.java
@@ -20,21 +20,26 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 import org.testng.annotations.BeforeClass;
 
+import au.gov.ga.geodesy.domain.model.SynchronousEventPublisher;
+import au.gov.ga.geodesy.domain.model.equipment.EquipmentFactory;
+import au.gov.ga.geodesy.domain.service.CorsSiteService;
+import au.gov.ga.geodesy.domain.service.IgsSiteLogService;
+import au.gov.ga.geodesy.domain.service.PositionService;
+import au.gov.ga.geodesy.domain.service.WeeklySolutionService;
+import au.gov.ga.geodesy.igssitelog.support.marshalling.moxy.IgsSiteLogMoxyMarshaller;
+import au.gov.ga.geodesy.port.adapter.geodesyml.GeodesyMLValidator;
+import au.gov.ga.geodesy.port.adapter.sopac.SiteLogSopacReader;
+import au.gov.ga.geodesy.support.mapper.orika.SiteLogOrikaMapper;
 import au.gov.ga.geodesy.support.spring.GeodesyRepositoryRestMvcConfig;
 import au.gov.ga.geodesy.support.spring.GeodesyRestMvcConfig;
-import au.gov.ga.geodesy.support.spring.GeodesyServiceTestConfig;
-import au.gov.ga.geodesy.support.spring.GeodesySupportConfig;
 import au.gov.ga.geodesy.support.spring.PersistenceJpaConfig;
+import au.gov.ga.geodesy.support.spring.TestAppConfig;
 
-@ContextConfiguration(
-        classes = {
-            GeodesySupportConfig.class,
-            GeodesyServiceTestConfig.class,
-            GeodesyRepositoryRestMvcConfig.class,
-            GeodesyRestMvcConfig.class,
-            PersistenceJpaConfig.class
-        },
-        loader = AnnotationConfigWebContextLoader.class)
+@ContextConfiguration(classes = {TestAppConfig.class, IgsSiteLogService.class, SynchronousEventPublisher.class,
+        GeodesyMLValidator.class, SiteLogSopacReader.class, IgsSiteLogMoxyMarshaller.class, SiteLogOrikaMapper.class,
+        WeeklySolutionService.class, CorsSiteService.class, EquipmentFactory.class, PositionService.class,
+        GeodesyRepositoryRestMvcConfig.class, GeodesyRestMvcConfig.class,
+        PersistenceJpaConfig.class}, loader = AnnotationConfigWebContextLoader.class)
 
 @WebAppConfiguration
 @Transactional("geodesyTransactionManager")

--- a/src/test/java/au/gov/ga/geodesy/support/spring/TestAppConfig.java
+++ b/src/test/java/au/gov/ga/geodesy/support/spring/TestAppConfig.java
@@ -4,18 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 
-import au.gov.ga.geodesy.domain.model.SynchronousEventPublisher;
-import au.gov.ga.geodesy.domain.model.event.EventPublisher;
-
 @Configuration
-public class GeodesyServiceTestConfig extends GeodesyServiceConfig {
-
-    @Bean
-    @Override
-    public EventPublisher eventPublisher() {
-        return new SynchronousEventPublisher();
-    }
-
+public class TestAppConfig {
     /**
      * @return a PropertySourcesPlaceholderConfigurer for wiring @value ${xxx} resources
      */
@@ -25,4 +15,5 @@ public class GeodesyServiceTestConfig extends GeodesyServiceConfig {
 
         return p;
     }
+
 }


### PR DESCRIPTION
I had problems when trying to integrate the email notifications code in as the tests pulled in every artifact via GeodesyServiceTestConfig via GeodesyServiceConfig.  The trouble with this is that every class, whether wanted or not and if relevant to the test or not are included and wired up.  This was seen to be a real issue in one fix where the test Asserted some number of records existed.  But that Service class (NodeService was one) wasn't explicitly mentioned in the test (ie. Autowired).  It was by virtue of being in the package that it was instantiated so that when the respective Repository.count() was called (eg. NodeRepository.count()) the value was what was expected (Asserted).

I have removed the use of GeodesyServiceTestConfig / GeodesyServiceConfig from all tests now and replaced with explicit X.class in the \@Configuration header.

This also removed the AspectJ weaving that was in GeodesyServiceConfig and I replaced the only use of this with different code.  That was in SiteLogSopacReader and its super-class SiteLogReader.

Now all the tests run in Eclipse also 🎱   And pass 👍 