### PR TITLE
#113 Update since now using CountryCode CodeLists

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,12 @@
             <version>0.17.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.0.52-beta</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverter.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverter.java
@@ -18,6 +18,9 @@ import net.opengis.iso19139.gco.v_20070417.CodeListValueType;
 public class CodeListValueTypeConverter implements CustomConverter {
     Logger logger = LoggerFactory.getLogger(getClass());
 
+    private CodeListValueTypeConverterInstanceFactory codeListValueTypeConverterInstanceFactory = new CodeListValueTypeConverterInstanceFactory();
+
+    @Override
     @SuppressWarnings("rawtypes")
     public Object convert(Object destination, Object source, Class destClass, Class sourceClass) {
         if (source == null) {
@@ -35,12 +38,12 @@ public class CodeListValueTypeConverter implements CustomConverter {
             } else {
                 destClassInstance = destination;
             }
-            CodeListValueType destClassInstanceType =  (CodeListValueType) destClassInstance;
-            destClassInstanceType.setValue((String) source);
-            // TODO set proper codeLists
-            destClassInstanceType.setCodeList("codelist");
-            destClassInstanceType.setCodeListValue("codeListValue");
-            return destClassInstance;
+            CodeListValueType destClassInstanceType = (CodeListValueType) destClassInstance;
+            // Handle the different subclasses of CodeListValueType
+            CodeListValueTypeConverterInstanceBase subConverter = codeListValueTypeConverterInstanceFactory
+                    .getCodeListValueTypeConverterInstance(destClassInstanceType);
+            subConverter.doConversion((String) source);
+            return subConverter.getCodeListValueType();
         } else if (source instanceof CodeListValueType) {
             return ((CodeListValueType) source).getValue();
         } else {

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterInstanceBase.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterInstanceBase.java
@@ -1,0 +1,43 @@
+package au.gov.ga.geodesy.support.mapper.dozer.converter;
+
+import au.gov.ga.geodesy.exception.GeodesyRuntimeException;
+import net.opengis.iso19139.gco.v_20070417.CodeListValueType;
+
+/**
+ * There are a number of classes that extend CodeListValueType and the converter fired for each of these is CodeListValueTypeConverter.
+ * However each type needs an opportunity to do the conversion. This is a base class for the classes that have that purpose.
+ * 
+ * @author brookes
+ *
+ */
+public abstract class CodeListValueTypeConverterInstanceBase {
+    private CodeListValueType codeListValueType;
+
+    protected void setCodeListValueType(CodeListValueType codeListValueType) {
+        this.codeListValueType = codeListValueType;
+    }
+
+    protected CodeListValueType getCodeListValueType() {
+        if (this.codeListValueType == null) {
+            throw new GeodesyRuntimeException("ERROR - this.codeListValueType not defined!");
+        }
+        return this.codeListValueType;
+    }
+
+    public CodeListValueType doConversion(String sourceInput) {
+        setValue(sourceInput);
+        setCodeList(sourceInput);
+        setCodeListValue(sourceInput);
+        setCodeSpace(sourceInput);
+        return getCodeListValueType();
+    }
+
+    public abstract void setValue(String value);
+
+    public abstract void setCodeList(String codeList);
+
+    public abstract void setCodeListValue(String codeListValue);
+
+    public abstract void setCodeSpace(String codeSpace);
+
+}

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterInstanceCountryCodeType.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterInstanceCountryCodeType.java
@@ -1,0 +1,30 @@
+package au.gov.ga.geodesy.support.mapper.dozer.converter;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Lazy
+@Component
+public class CodeListValueTypeConverterInstanceCountryCodeType extends CodeListValueTypeConverterInstanceBase {
+
+    @Override
+    public void setValue(String value) {
+        getCodeListValueType().setValue(value);
+    }
+
+    @Override
+    public void setCodeList(String codeList) {
+        getCodeListValueType().setCodeList(
+                "http://xml.gov.au/icsm/geodesyml/codelists/countryCodes_codelist.xml#GeodesyML_CountryCode");
+    }
+
+    @Override
+    public void setCodeListValue(String codeListValue) {
+        getCodeListValueType().setCodeListValue(codeListValue);
+    }
+
+    @Override
+    public void setCodeSpace(String codeSpace) {
+        getCodeListValueType().setCodeSpace("urn:iso:country-code");
+    }
+}

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterInstanceDefault.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterInstanceDefault.java
@@ -1,0 +1,29 @@
+package au.gov.ga.geodesy.support.mapper.dozer.converter;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Lazy
+@Component
+public class CodeListValueTypeConverterInstanceDefault extends CodeListValueTypeConverterInstanceBase {
+
+    @Override
+    public void setValue(String value) {
+        getCodeListValueType().setValue(value);
+    }
+
+    @Override
+    public void setCodeList(String codeList) {
+        getCodeListValueType().setCodeList(codeList);
+    }
+
+    @Override
+    public void setCodeListValue(String codeListValue) {
+        getCodeListValueType().setCodeListValue(codeListValue);
+    }
+
+    @Override
+    public void setCodeSpace(String codeSpace) {
+        getCodeListValueType().setCodeSpace(codeSpace);
+    }
+}

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterInstanceFactory.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterInstanceFactory.java
@@ -1,0 +1,60 @@
+package au.gov.ga.geodesy.support.mapper.dozer.converter;
+
+import net.opengis.iso19139.gco.v_20070417.CodeListValueType;
+
+/**
+ * Factory to create CodeListValueTypeConverterInstance's to manage specific needs for converting to CodeListValueType from String.
+ * Only one instance of this class will be created by Dozer.
+ * 
+ * @author brookes
+ *
+ */
+public class CodeListValueTypeConverterInstanceFactory {
+    private ConverterInstanceFactory converterInstanceFactory = new ConverterInstanceFactory();
+    private CodeListValueTypeConverterInstanceCountryCodeType countryCodeTypeConverter;
+    private CodeListValueTypeConverterInstanceDefault defaultConverter;
+
+    public CodeListValueTypeConverterInstanceBase getCodeListValueTypeConverterInstance(
+            CodeListValueType codeListValueTypeSuperClass) {
+        return converterInstanceFactory.getCodeListValueTypeConverterInstance(codeListValueTypeSuperClass);
+    }
+
+    class ConverterInstanceFactory {
+
+        /**
+         * 
+         * @param codeListValueTypeSuperClass
+         * @return a CodeListValueTypeConverterInstanceBase super class that can handle the conversion of String to CodeListValueType based
+         *         on the CodeListValueType runtime instance (super-class of it)
+         */
+        public CodeListValueTypeConverterInstanceBase getCodeListValueTypeConverterInstance(
+                CodeListValueType codeListValueTypeSuperClass) {
+            CodeListValueTypeConverterInstanceBase converter = null;
+            switch (codeListValueTypeSuperClass.getClass().getSimpleName()) {
+            case "CountryCodeType":
+                converter = getCountryCodeTypeConverter();
+                converter.setCodeListValueType(codeListValueTypeSuperClass);
+                return converter;
+            default:
+                converter = getDefaultConverter();
+                converter.setCodeListValueType(codeListValueTypeSuperClass);
+                return converter;
+            }
+        }
+
+    }
+
+    CodeListValueTypeConverterInstanceBase getDefaultConverter() {
+        if (defaultConverter == null) {
+            defaultConverter = new CodeListValueTypeConverterInstanceDefault();
+        }
+        return defaultConverter;
+    }
+
+    CodeListValueTypeConverterInstanceBase getCountryCodeTypeConverter() {
+        if (countryCodeTypeConverter == null) {
+            countryCodeTypeConverter = new CodeListValueTypeConverterInstanceCountryCodeType();
+        }
+        return countryCodeTypeConverter;
+    }
+}

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/populator/SiteLocationTypePopulator.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/populator/SiteLocationTypePopulator.java
@@ -27,7 +27,7 @@ public class SiteLocationTypePopulator extends GeodesyMLElementPopulator<SiteLoc
     void checkAllRequiredElementsPopulated(SiteLocationType siteLocationType) {
         checkElementPopulated(siteLocationType, "city", GMLMiscTools.getEmptyString());
         checkElementPopulated(siteLocationType, "state", GMLMiscTools.getEmptyString());
-        checkElementPopulated(siteLocationType, "countryCodeISO", GMLMiscTools.getEmptyString());
+        checkElementPopulated(siteLocationType, "countryCodeISO", GMLMiscTools.getEmptyCountryCode());
         checkElementPopulated(siteLocationType, "tectonicPlate", GMLGmlTools.getEmptyCodeType());
         checkElementPopulated(siteLocationType, "approximatePositionITRF",
                 GMLGeoTools.buildZeroApproximatePositionITRF());
@@ -38,10 +38,16 @@ public class SiteLocationTypePopulator extends GeodesyMLElementPopulator<SiteLoc
         super.postWritingDestinationValue(event);
 
         SiteLocationType siteLocationType = (SiteLocationType) event.getDestinationObject();
-        String country = siteLocationType.getCountryCodeISO();
-        String code = COUNTRY_CODES_ALPHA_3.lookupCode(country);
-        siteLocationType.setCountryCodeISO(code);
-        logger.debug(String.format("Change country: '%s' to code '%s'", country, code));
+        String code = "";
+        if (siteLocationType.getCountryCodeISO() != null) {
+            String country = siteLocationType.getCountryCodeISO().getCodeListValue();
+            code = COUNTRY_CODES_ALPHA_3.lookupCode(country);
+            siteLocationType.getCountryCodeISO().setCodeListValue(code);
+            logger.debug(String.format("Change country: '%s' to code '%s'", country, code));
+        } else {
+            checkElementPopulated(siteLocationType, "countryCodeISO", GMLMiscTools.getEmptyCountryCode());
+            logger.warn("ERROR siteLocationType.ountryCodeISO is null");
+        }
     }
 
     /**

--- a/src/main/java/au/gov/ga/geodesy/support/utils/GMLMiscTools.java
+++ b/src/main/java/au/gov/ga/geodesy/support/utils/GMLMiscTools.java
@@ -3,6 +3,8 @@ package au.gov.ga.geodesy.support.utils;
 import java.util.ArrayList;
 import java.util.List;
 
+import au.gov.xml.icsm.geodesyml.v_0_3.CountryCodeType;
+
 public class GMLMiscTools {
     public static String getEmptyString() {
         return "";
@@ -21,5 +23,11 @@ public class GMLMiscTools {
         List<T> list = getEmptyList(clazz);
         list.add(dummyItem);
         return list;
+    }
+
+    public static Object getEmptyCountryCode() {
+        CountryCodeType countryCodeType = new CountryCodeType();
+        countryCodeType.setCodeListValue("");
+        return countryCodeType;
     }
 }

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/TranslateTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/TranslateTest.java
@@ -154,8 +154,8 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(geodesyML.getElements().size(), 1);
         Assert.assertTrue(geodesyML.getElements().get(0) instanceof JAXBElement); // TODO: remove this check
 
-        Stream<SiteLogType> siteLogTypeStream = GeodesyMLUtils.getElementFromJAXBElements(
-                geodesyML.getElements(), SiteLogType.class);
+        Stream<SiteLogType> siteLogTypeStream = GeodesyMLUtils.getElementFromJAXBElements(geodesyML.getElements(),
+                SiteLogType.class);
 
         SiteLogType siteLogType = siteLogTypeStream.collect(Collectors.toList()).get(0);
         return siteLogType;
@@ -191,7 +191,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         SiteLocationType siteLocationType = siteLogType.getSiteLocation();
         Assert.assertEquals(Double.parseDouble(siteLocationType.getApproximatePositionITRF().getXCoordinateInMeters()),
                 Double.parseDouble("-4052051.7670"));
-        Assert.assertEquals("AUS", siteLocationType.getCountryCodeISO());
+        Assert.assertEquals(siteLocationType.getCountryCodeISO().getCodeListValue(), "AUS");
         Assert.assertEquals(siteLocationType.getCity(), "Alice Springs");
         Assert.assertEquals(siteLocationType.getState(), "Northern Territory");
         Assert.assertEquals(siteLocationType.getTectonicPlate().getValue(), "Australian");

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterInstanceCountryCodeTypeTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterInstanceCountryCodeTypeTest.java
@@ -1,0 +1,30 @@
+package au.gov.ga.geodesy.support.mapper.dozer.converter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.opengis.iso19139.gco.v_20070417.CodeListValueType;
+
+public class CodeListValueTypeConverterInstanceCountryCodeTypeTest {
+
+    private CodeListValueTypeConverterInstanceCountryCodeType ctv = new CodeListValueTypeConverterInstanceCountryCodeType();
+    private CodeListValueType codeListValueType = new CodeListValueType();
+
+    @Before
+    public void init() {
+        ctv.setCodeListValueType(codeListValueType);
+    }
+
+    @Test
+    public void test01() {
+        String source = "AUS";
+
+        CodeListValueType codeListValueType = ctv.doConversion(source);
+        Assert.assertEquals("http://xml.gov.au/icsm/geodesyml/codelists/countryCodes_codelist.xml#GeodesyML_CountryCode", codeListValueType.getCodeList());
+        Assert.assertEquals("AUS", codeListValueType.getCodeListValue());
+        Assert.assertEquals("urn:iso:country-code", codeListValueType.getCodeSpace());
+        System.out.println(codeListValueType);
+    }
+
+}

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/converter/CodeListValueTypeConverterTest.java
@@ -1,9 +1,18 @@
 package au.gov.ga.geodesy.support.mapper.dozer.converter;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import au.gov.xml.icsm.geodesyml.v_0_4.IgsReceiverModelCodeType;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import au.gov.ga.geodesy.exception.GeodesyRuntimeException;
 import net.opengis.iso19139.gco.v_20070417.CodeListValueType;
 
 /**
@@ -12,13 +21,31 @@ import net.opengis.iso19139.gco.v_20070417.CodeListValueType;
  * au.gov.xml.icsm.geodesyml.v_0_3.IgsAntennaModelCodeType
  *
  */
+@RunWith(MockitoJUnitRunner.class)
 public class CodeListValueTypeConverterTest {
-    CodeListValueTypeConverter ctv = new CodeListValueTypeConverter();
+    @Mock
+    private CodeListValueTypeConverterInstanceFactory codeListValueTypeConverterInstanceFactory = new CodeListValueTypeConverterInstanceFactory();
+
+    private CodeListValueTypeConverterInstanceDefault defaultConverter = new CodeListValueTypeConverterInstanceDefault();
+
+    @InjectMocks
+    private CodeListValueTypeConverter ctv;
+
+    @Before
+    public void init() {
+        Mockito.when(codeListValueTypeConverterInstanceFactory.getCodeListValueTypeConverterInstance(Matchers.any()))
+                .thenReturn(defaultConverter);
+    }
 
     @Test
     public void testStringSourceDestinationCodeListValueTypeNull() {
         CodeListValueType destination = null;
         String source = "banana";
+        CodeListValueType emptyCodeListValueType = new CodeListValueType();
+
+        // .setCodeListValueType() only necessary due to the Mockito.when init
+        defaultConverter.setCodeListValueType(emptyCodeListValueType);
+
         CodeListValueType c = (CodeListValueType) ctv.convert(destination, source, CodeListValueType.class,
                 String.class);
 
@@ -30,6 +57,10 @@ public class CodeListValueTypeConverterTest {
         CodeListValueType destination = new CodeListValueType();
         destination.setValue("Not a banana");
         String source = "banana";
+
+        // .setCodeListValueType() only necessary due to the Mockito.when init
+        defaultConverter.setCodeListValueType(destination);
+
         CodeListValueType c = (CodeListValueType) ctv.convert(destination, source, CodeListValueType.class,
                 String.class);
 
@@ -58,10 +89,25 @@ public class CodeListValueTypeConverterTest {
 
     // ========================
 
+    // Since .setCodeListValueType() not called due to Mockito.when init
+    @Test(expected = GeodesyRuntimeException.class)
+    public void testNoArgShouldThrowException() {
+        IgsReceiverModelCodeType destination = null;
+        String source = "banana";
+        @SuppressWarnings("unused")
+        IgsReceiverModelCodeType c = (IgsReceiverModelCodeType) ctv.convert(destination, source,
+                IgsReceiverModelCodeType.class, String.class);
+    }
+
     @Test
     public void testStringSourceDestinationIgsReceiverModelCodeListValueTypeNull() {
         IgsReceiverModelCodeType destination = null;
         String source = "banana";
+
+        IgsReceiverModelCodeType emptyCodeListValueType = new IgsReceiverModelCodeType();
+
+        // .setCodeListValueType() only necessary due to the Mockito.when init
+        defaultConverter.setCodeListValueType(emptyCodeListValueType);
         IgsReceiverModelCodeType c = (IgsReceiverModelCodeType) ctv.convert(destination, source,
                 IgsReceiverModelCodeType.class, String.class);
 
@@ -72,6 +118,10 @@ public class CodeListValueTypeConverterTest {
     public void testStringSourceDestinationIgsReceiverModelCodeListValueTypeNotNull() {
         IgsReceiverModelCodeType destination = new IgsReceiverModelCodeType();
         String source = "banana";
+
+        // .setCodeListValueType() only necessary due to the Mockito.when init
+        defaultConverter.setCodeListValueType(destination);
+
         IgsReceiverModelCodeType c = (IgsReceiverModelCodeType) ctv.convert(destination, source,
                 IgsReceiverModelCodeType.class, String.class);
 


### PR DESCRIPTION
* Due to Dozer working with super types, I couldn't have a CountryCode to/from String mapper.  Instead there is a Factory in the CodeLists to / from String mapper that selects that specific super types (either CountryCode or default (everything else))
