### PR TITLE
Configure mapper to work with empty beans

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/support/spring/GeodesyRepositoryRestMvcConfig.java
+++ b/src/main/java/au/gov/ga/geodesy/support/spring/GeodesyRepositoryRestMvcConfig.java
@@ -56,7 +56,7 @@ public class GeodesyRepositoryRestMvcConfig extends RepositoryRestMvcConfigurati
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"); // ISO 8601
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
         mapper.setDateFormat(format);
- 
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         mapper.registerModule(new SimpleModule() {
             public void setupModule(SetupContext context) {
                 super.setupModule(context);


### PR DESCRIPTION
The JSON mapper was throwing an error similar to a Lazy Initialization
exception when the object contained an unitialised collection, fixed this by adding a serialisation feature configuration setting.
Symptom: after adding a sitelog, try to access the endpoint http://localhost:8080/geodesy-web-services/siteLogs{?page,size,sort} 
