### PR TITLE
Fix Sopac to GeodesyMl translate after Date to Instant change

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePositionTypeInstantConverter.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePositionTypeInstantConverter.java
@@ -11,7 +11,7 @@ import net.opengis.gml.v_3_2_1.TimePositionType;
 /**
  * Converter: java.time.Instant <--> net.opengis.gml.v_3_2_1.TimePositionType
  */
-public class TimePositionTypeDateConverter implements CustomConverter {
+public class TimePositionTypeInstantConverter implements CustomConverter {
 
     @SuppressWarnings("rawtypes")
     public Object convert(Object destination, Object source, Class destClass, Class sourceClass) {

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/decorator/ChangeTrackingDecoratorTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/decorator/ChangeTrackingDecoratorTest.java
@@ -10,6 +10,7 @@ import java.time.ZoneOffset;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import au.gov.ga.geodesy.domain.model.sitelog.GnssReceiverLogItem;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -126,6 +127,19 @@ public class ChangeTrackingDecoratorTest {
 
         GnssReceiverType out = GeodesyMLDecorators.addDecorators(element,element);
         Assert.assertEquals(element, out);
+    }
+
+    @Test public void test03_GNSSReceiver() {
+        // After some changes the dateInstalled TimePositionType's value is not being mapped to the decorated object - find out why
+        // Good test to have but this is not where the error is
+        String testDate = "2007-12-03T10:15:30Z";
+        GnssReceiverLogItem gnssReceiverLogItem = new GnssReceiverLogItem();
+        gnssReceiverLogItem.setSerialNumber("1234");
+        gnssReceiverLogItem.setDateInstalled(Instant.parse(testDate));
+        GnssReceiverLogItem out = GeodesyMLDecorators.addDecorators(gnssReceiverLogItem);
+        Assert.assertNotNull(out);
+        Assert.assertNotNull(out.getDateInstalled());
+        Assert.assertEquals(testDate, out.getDateInstalled().toString());
     }
 
     private static TimePositionType createTimePositionType() {

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/DozerDelegateTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/DozerDelegateTest.java
@@ -1,0 +1,28 @@
+package au.gov.ga.geodesy.support.mapper.dozer;
+
+import au.gov.ga.geodesy.domain.model.sitelog.GnssReceiverLogItem;
+import au.gov.ga.geodesy.support.mapper.decorator.GeodesyMLDecorators;
+import au.gov.xml.icsm.geodesyml.v_0_3.GnssReceiverType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static org.junit.Assert.*;
+
+public class DozerDelegateTest {
+    @Test
+    public void mapWithGuardWithDecorators() throws Exception {
+        // After some changes the dateInstalled TimePositionType's value is not being mapped to the decorated object - find out why
+        // The problem was the translator mapping (ie. just the XML) - it needed to change from Date to Instant
+        String testDate = "2007-12-03T10:15:31Z";
+        GnssReceiverLogItem gnssReceiverLogItem = new GnssReceiverLogItem();
+        gnssReceiverLogItem.setSerialNumber("1234");
+        gnssReceiverLogItem.setDateInstalled(Instant.parse(testDate));
+        GnssReceiverType out = DozerDelegate.mapWithGuardWithDecorators(gnssReceiverLogItem, GnssReceiverType.class);
+        Assert.assertNotNull(out);
+        Assert.assertNotNull(out.getDateInstalled());
+        Assert.assertEquals(testDate, out.getDateInstalled().getValue().get(0));
+    }
+
+}

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/TranslateTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/TranslateTest.java
@@ -69,11 +69,11 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
     /**
      * Location of input test data - original location of files that haven't been modified
      */
-    private final static String SITEDATADIR = "sitelog";
+    private final static String SITEDATADIR = "sitelog/sopac";
     /**
      * Location of input test data - same as that in SITEDATADIR though modified in some way to improve or fix test
      */
-    private final static String TESTDATADIR = "testData";
+    private final static String TESTDATADIR = "sitelog/testData";
 
     // @Autowired
     private IgsSiteLogXmlMarshaller marshaller;
@@ -172,11 +172,8 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         FormInformationType formIdentificationType = siteLogType.getFormInformation();
         Assert.assertEquals(formIdentificationType.getPreparedBy(), "Nick Dando");
 
-        // Input is 2013-07-08 and because there is no time-zone, it gets the local one (8 July 2013 +10 or +11)
-        // GMT (the dateFormat uses forces GMT) will be the day before and due to daylight savings ambiguity I won't
-        // check the time
         MatcherAssert.assertThat("formIdentificationType.getDatePrepared()",
-                formIdentificationType.getDatePrepared().getValue().get(0), Matchers.startsWith("2013-07-07"));
+                formIdentificationType.getDatePrepared().getValue().get(0), Matchers.startsWith("2013-07-08"));
 
         Assert.assertEquals(formIdentificationType.getReportType(), "UPDATE");
         // These don't exist (should they - Mmm, not in Sopac SiteLog either so no)?
@@ -290,7 +287,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(frequencyStandardType.getStandardType().getValue(), "QUARTZ/INTERNAL");
         Assert.assertEquals(GMLDateUtils.stringToDateToStringMultiParsers(TimePrimitivePropertyTypeUtils
                 .getTheTimePeriodType(frequencyStandardType.getValidTime()).getBeginPosition().getValue().get(0)),
-                "15 May 1994 00:00 GMT");
+                "1994-05-15T00:00:00.000Z");
 
         // Humidity Sensors
         List<HumiditySensorPropertyType> humiditySensors = siteLogType.getHumiditySensors();
@@ -302,7 +299,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(
                 GMLDateUtils.stringToDateToStringMultiParsers(TimePrimitivePropertyTypeUtils
                         .getTheTimePeriodType(humiditySensor.getValidTime()).getBeginPosition().getValue().get(0)),
-                "29 Mar 2006 00:00 GMT");
+                "2006-03-29T00:00:00.000Z");
         Assert.assertEquals(humiditySensor.getSerialNumber(), "98850");
         Assert.assertEquals(humiditySensor.getHeightDiffToAntenna(), 2.4, 0.001);
         Assert.assertEquals(humiditySensor.getDataSamplingInterval(), 30, 0.01);
@@ -319,7 +316,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(
                 GMLDateUtils.stringToDateToStringMultiParsers(TimePrimitivePropertyTypeUtils
                         .getTheTimePeriodType(pressureSensor.getValidTime()).getBeginPosition().getValue().get(0)),
-                "29 Mar 2006 00:00 GMT");
+                "2006-03-29T00:00:00.000Z");
         Assert.assertEquals(pressureSensor.getManufacturer(), "Paroscientific, Inc.");
         Assert.assertEquals(pressureSensor.getSerialNumber(), "98850");
         Assert.assertEquals(pressureSensor.getHeightDiffToAntenna(), 2.4, 0.01);
@@ -335,7 +332,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(
                 GMLDateUtils.stringToDateToStringMultiParsers(TimePrimitivePropertyTypeUtils
                         .getTheTimePeriodType(waterVapourSensor.getValidTime()).getBeginPosition().getValue().get(0)),
-                "29 Mar 2006 00:00 GMT");
+                "2006-03-29T00:00:00.000Z");
 
         // Temperature Sensors
         List<TemperatureSensorPropertyType> temperatureSensors = siteLogType.getTemperatureSensors();
@@ -348,7 +345,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(
                 GMLDateUtils.stringToDateToStringMultiParsers(TimePrimitivePropertyTypeUtils
                         .getTheTimePeriodType(temperatureSensor.getValidTime()).getBeginPosition().getValue().get(0)),
-                "29 Mar 2006 00:00 GMT");
+                "2006-03-29T00:00:00.000Z");
         Assert.assertEquals(temperatureSensor.getSerialNumber(), "98850");
         Assert.assertEquals(temperatureSensor.getHeightDiffToAntenna(), 2.4, 0.001);
         Assert.assertEquals(temperatureSensor.getDataSamplingInterval().doubleValue(), 30, 0.001);
@@ -365,7 +362,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(
                 GMLDateUtils.stringToDateToStringMultiParsers(TimePrimitivePropertyTypeUtils
                         .getTheTimeInstantType(localEpisodicEvent.getValidTime()).getTimePosition().getValue().get(0)),
-                "20 Jul 2011");
+                "2011-07-20T00:00:00.000Z");
 
         // Contacts
         CIResponsiblePartyType siteContact = siteLogType.getSiteContact().get(0).getCIResponsibleParty();
@@ -399,7 +396,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
     @Test
     public void testARTU() throws MarshallingException, IOException,
             au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, ParseException {
-        GeodesyMLType geodesyML = testTranslate(SITEDATADIR, "ARTU");
+        GeodesyMLType geodesyML = testTranslate(TESTDATADIR, "ARTU");
 
         Assert.assertNotNull(geodesyML);
     }
@@ -438,7 +435,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(
                 GMLDateUtils.stringToDateToStringMultiParsers(TimePrimitivePropertyTypeUtils
                         .getTheTimePeriodType(radioInterference.getValidTime()).getBeginPosition().getValue().get(0)),
-                "31 Mar 2015 00:00 GMT");
+                "2015-03-31T00:00:00.000Z");
 
         // MultipathSourcesPropertyType
         List<MultipathSourcesPropertyType> multipathSources = siteLogType.getMultipathSourcesSet();
@@ -451,7 +448,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(
                 GMLDateUtils.stringToDateToStringMultiParsers(TimePrimitivePropertyTypeUtils
                         .getTheTimePeriodType(multipathSource.getValidTime()).getBeginPosition().getValue().get(0)),
-                "30 Mar 2015 00:00 GMT");
+                "2015-03-30T00:00:00.000Z");
 
         // SignalObstructionsPropertyType
         List<SignalObstructionsPropertyType> signalObstructions = siteLogType.getSignalObstructionsSet();
@@ -464,7 +461,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(
                 GMLDateUtils.stringToDateToStringMultiParsers(TimePrimitivePropertyTypeUtils
                         .getTheTimePeriodType(signalObstruction.getValidTime()).getBeginPosition().getValue().get(0)),
-                "29 Mar 2015 00:00 GMT");
+                "2015-03-29T00:00:00.000Z");
 
         // Contacts - just different and new parts (compared to ALIC)
         CIResponsiblePartyType siteContact = siteLogType.getSiteContact().get(0).getCIResponsibleParty();
@@ -511,7 +508,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
     @Test
     public void testAMC2() throws MarshallingException, IOException,
             au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, ParseException {
-        GeodesyMLType geodesyML = testTranslate(SITEDATADIR, "AMC2");
+        GeodesyMLType geodesyML = testTranslate(TESTDATADIR, "AMC2");
 
         Assert.assertNotNull(geodesyML);
     }
@@ -559,7 +556,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
     @Test
     public void testZAMB() throws MarshallingException, IOException,
             au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, ParseException {
-        GeodesyMLType geodesyML = testTranslate(SITEDATADIR, "ZAMB");
+        GeodesyMLType geodesyML = testTranslate(TESTDATADIR, "ZAMB");
 
         Assert.assertNotNull(geodesyML);
     }
@@ -655,7 +652,7 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
     @Test
     public void testCRAO() throws MarshallingException, IOException,
             au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, ParseException {
-        GeodesyMLType geodesyML = testTranslate(SITEDATADIR, "CRAO");
+        GeodesyMLType geodesyML = testTranslate(TESTDATADIR, "CRAO");
 
         Assert.assertNotNull(geodesyML);
     }
@@ -663,7 +660,8 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
     @Test
     public void testCRO1() throws MarshallingException, IOException,
             au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, ParseException {
-        GeodesyMLType geodesyML = testTranslate(SITEDATADIR, "CRO1");
+        GeodesyMLType geodesyML = testTranslate(TESTDATADIR, "CRO1");
+
 
         Assert.assertNotNull(geodesyML);
     }

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePositionTypeInstantConverterTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePositionTypeInstantConverterTest.java
@@ -2,23 +2,23 @@ package au.gov.ga.geodesy.support.mapper.dozer.converter;
 
 import java.text.ParseException;
 import java.time.Instant;
-import java.time.ZoneId;
 
+import au.gov.ga.geodesy.exception.GeodesyRuntimeException;
 import org.junit.Assert;
 import org.junit.Test;
 
 import au.gov.ga.geodesy.support.utils.GMLDateUtils;
 import net.opengis.gml.v_3_2_1.TimePositionType;
 
-public class TimePositionTypeDateConverterTest {
+public class TimePositionTypeInstantConverterTest {
     private Instant instantDate = Instant.now();
 
-    TimePositionTypeDateConverter conv = new TimePositionTypeDateConverter();
+    TimePositionTypeInstantConverter conv = new TimePositionTypeInstantConverter();
 
     /**
      * source: String
      * dest: TimePositionType (TimeInstantType)
-     * 
+     *
      * @throws ParseException
      */
     @Test
@@ -30,13 +30,9 @@ public class TimePositionTypeDateConverterTest {
         Assert.assertEquals(expected, out.getValue().get(0));
     }
 
-    @Test
+    @Test(expected = GeodesyRuntimeException.class)
     public void test2() throws ParseException {
         Instant in = GMLDateUtils.stringToDateMultiParsers("2011-20-07"); // in-correct format
-        TimePositionType out = null;
-        String expected = "2011-07-20T00:00:00Z";
-        out = (TimePositionType) conv.convert(out, in, TimePositionType.class, String.class);
-        Assert.assertEquals(expected, out.getValue().get(0));
     }
 
     @Test
@@ -60,6 +56,11 @@ public class TimePositionTypeDateConverterTest {
         out = (Instant) conv.convert(out, in, TimePositionType.class, Instant.class);
         String dateOut = GMLDateUtils.dateToString(out, GMLDateUtils.GEODESYML_DATE_FORMAT_TIME_OUTPUT);
         Assert.assertEquals(expected, dateOut);
+    }
+
+    @Test(expected = GeodesyRuntimeException.class)
+    public void testBadFormat() {
+        Instant in = GMLDateUtils.stringToDateMultiParsers("2008-03-26T00");
     }
 
     /* ****************************************** */

--- a/src/test/resources/sitelog/testData/AMC2.xml
+++ b/src/test/resources/sitelog/testData/AMC2.xml
@@ -1,0 +1,290 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<igsSiteLog xmlns="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004" xmlns:contact="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/contact/2004" xmlns:equip="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004" xmlns:li="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004" xmlns:mi="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004  http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004/igsSiteLog.xsd"><!--Alice Springs Station Log-->
+<!--Version 0.01-->
+<!--Geoscience Australia Geodesy-->
+<!--For More Information regarding XML based Site Logs go to-->
+<!--http://sopac.ucsd.edu/projects/xml-->
+
+  <formInformation>
+    <mi:preparedBy>Tatevik Shakhbandaryan</mi:preparedBy>
+    <mi:datePrepared>2013-03-14</mi:datePrepared>
+    <mi:reportType>UPDATE</mi:reportType>
+    <mi:previousLog>amc2_20071009.log</mi:previousLog>
+    <mi:modifiedSections>0,10.1</mi:modifiedSections>
+  </formInformation>
+  <siteIdentification>
+    <mi:siteName>Alternate Master Clock (UTC calibrated)</mi:siteName>
+    <mi:fourCharacterID>AMC2</mi:fourCharacterID>
+    <mi:monumentInscription>no monument, GPS antenna ARP</mi:monumentInscription>
+    <mi:iersDOMESNumber>40472S004</mi:iersDOMESNumber>
+    <mi:cdpNumber>none</mi:cdpNumber>
+    <mi:monumentDescription>(PILLAR/BRASS PLATE/STEEL MAST/etc)</mi:monumentDescription>
+    <mi:heightOfTheMonument></mi:heightOfTheMonument>
+    <mi:monumentFoundation>(STEEL RODS, CONCRETE BLOCK, ROOF, etc)</mi:monumentFoundation>
+    <mi:foundationDepth></mi:foundationDepth>
+    <mi:markerDescription>(CHISELLED CROSS/DIVOT/BRASS NAIL/etc)</mi:markerDescription>
+    <mi:dateInstalled>1998-10-15</mi:dateInstalled>
+    <mi:geologicCharacteristic>(BEDROCK/CLAY/CONGLOMERATE/GRAVEL/SAND/etc)</mi:geologicCharacteristic>
+    <mi:bedrockType>(IGNEOUS/METAMORPHIC/SEDIMENTARY)</mi:bedrockType>
+    <mi:bedrockCondition>(FRESH/JOINTED/WEATHERED)</mi:bedrockCondition>
+    <mi:fractureSpacing>(1-10 cm/11-50 cm/51-200 cm/over 200 cm)</mi:fractureSpacing>
+    <mi:faultZonesNearby>(YES/NO/Name of the zone)</mi:faultZonesNearby>
+    <mi:distance-Activity>(multiple lines)</mi:distance-Activity>
+    <mi:notes>The antenna is mounted on top of the roof (flat) of Building 400 (5 stories) at Schriever Air Force Base, outside of Colorado Springs, Colorado.  There are no nearby geodetic markers or control points.</mi:notes>
+  </siteIdentification>
+  <siteLocation>
+    <mi:city>Colorado Springs</mi:city>
+    <mi:state>Colorado</mi:state>
+    <mi:country>U.S.A.</mi:country>
+    <mi:tectonicPlate>North American</mi:tectonicPlate>
+    <approximatePositionITRF>
+      <mi:xCoordinateInMeters>-1248596.252</mi:xCoordinateInMeters>
+      <mi:yCoordinateInMeters>-4819428.284</mi:yCoordinateInMeters>
+      <mi:zCoordinateInMeters>3976506.034</mi:zCoordinateInMeters>
+      <mi:latitude-North>+384811.25</mi:latitude-North>
+      <mi:longitude-East>-1043128.54</mi:longitude-East>
+      <mi:elevation-m_ellips.>1912.4898</mi:elevation-m_ellips.>
+    </approximatePositionITRF>
+    <mi:notes>Schriever Air Force Base</mi:notes>
+  </siteLocation>
+  <gnssReceiver>
+    <equip:receiverType>ROGUE SNR-12 RM</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>T247</equip:serialNumber>
+    <equip:firmwareVersion>3.2.32.4</equip:firmwareVersion>
+    <equip:elevationCutoffSetting></equip:elevationCutoffSetting>
+    <equip:dateInstalled>1998-03-24T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1998-10-15T22:01Z</equip:dateRemoved>
+    <equip:temperatureStabilization>(none or tolerance in degrees C)</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ROGUE SNR-12 RM</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>T245</equip:serialNumber>
+    <equip:firmwareVersion>3.2.32.4</equip:firmwareVersion>
+    <equip:elevationCutoffSetting></equip:elevationCutoffSetting>
+    <equip:dateInstalled>1998-10-15T22:01Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-03-08T18:54Z</equip:dateRemoved>
+    <equip:temperatureStabilization>(none or tolerance in degrees C)</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>AOA SNR-12 ACT</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>247-U</equip:serialNumber>
+    <equip:firmwareVersion>3.3.32.2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting></equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-03-09T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-05-10T17:48Z</equip:dateRemoved>
+    <equip:temperatureStabilization>(none or tolerance in degrees C)</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>AOA SNR-12 ACT</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>245-U</equip:serialNumber>
+    <equip:firmwareVersion>3.3.32.2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting></equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-05-11T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-09-01T15:09Z</equip:dateRemoved>
+    <equip:temperatureStabilization>(none or tolerance in degrees C)</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>AOA SNR-12 ACT</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>247-U</equip:serialNumber>
+    <equip:firmwareVersion>3.3.32.3</equip:firmwareVersion>
+    <equip:elevationCutoffSetting></equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-09-01T15:43Z</equip:dateInstalled>
+    <equip:dateRemoved>2000-07-10T20:39Z</equip:dateRemoved>
+    <equip:temperatureStabilization>(none or tolerance in degrees C)</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>AOA SNR-12 ACT</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>247-U</equip:serialNumber>
+    <equip:firmwareVersion>3.3.32.4</equip:firmwareVersion>
+    <equip:elevationCutoffSetting></equip:elevationCutoffSetting>
+    <equip:dateInstalled>2000-07-10T20:50Z</equip:dateInstalled>
+    <equip:dateRemoved>2002-06-21T00:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>(none or tolerance in degrees C)</equip:temperatureStabilization>
+    <equip:notes>firmware update only; no other change</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ASHTECH Z-XII3T</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>RT920013101</equip:serialNumber>
+    <equip:firmwareVersion>IL01-1D04-MCF-12MX</equip:firmwareVersion>
+    <equip:elevationCutoffSetting></equip:elevationCutoffSetting>
+    <equip:dateInstalled>2002-07-03T17:21Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>(none or tolerance in degrees C)</equip:temperatureStabilization>
+    <equip:notes>All pseudo-range data produced are calibrated to UTC(USNO) via the USNO Alternate Master Clock (AMC) which is typically maintained to 1 nanosecond (1 sigma) of the Primary USNO Master Clock in Washington DC.  No additional calibration corrections need to be applied to the RAW data set.</equip:notes>
+  </gnssReceiver>
+  <gnssAntenna>
+    <equip:antennaType>AOAD/M_T        NONE</equip:antennaType>
+    <equip:serialNumber>308</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0000</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>oriented North but not measured</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength></equip:antennaCableLength>
+    <equip:dateInstalled>1998-03-24T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2002-06-14T16:50Z</equip:dateRemoved>
+    <equip:notes>This antenna is located 28.5 inches nearly directly north of the antenna for a TTR-4P timing receiver.  NIMA surveyed the TTR-4P antenna location in August 1996 with the following results - 38 Degrees 48.2 N  ( 38.803107222 N) 255 Degrees 28.5 W  (255.475404583 E) 1911.087 m Ellipsoid Height with a stated accuracy of +/- 30 cm (1 sigma) in each component.  The TurboRogue antenna is mounted on a tripod platform. Antenna cable 25-AUG-1999 to present - Andrew FSJ1-50A (35422-33 phase stabilized) 1/4 inch Superflexible Foam Dielectric Heliax -- physical length 120 feet (36.57 m), mostly run in ceiling and floor of Bldg 400; measured electrical length is 146.9 ns +/- 30 ps specifications - Velocity factor 0.84 DC resistance 2 to 3 ohms per 1000 foot Capacitance, 24.2 pF/foot Inductance, .061 uH/foot Loss at 1250 MHz   6.77 dB/100 foot Loss at 1500 MHz   7.47 dB/100 foot Electrical Length Change verses Temperature - 400 PPM over (-40 to 30 C) or 5.7 PPM/C => 0.02 ps/m/C</equip:notes>
+  </gnssAntenna>
+  <gnssAntenna>
+    <equip:antennaType>AOAD/M_T        NONE</equip:antennaType>
+    <equip:serialNumber>KW-5-0001</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0000</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>oriented North but not measured</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>Andrew FSJ1-50A (35422-33 phase stabilized)</equip:antennaCableType>
+    <equip:antennaCableLength>36.57</equip:antennaCableLength>
+    <equip:dateInstalled>2002-06-14T16:51Z</equip:dateInstalled>
+    <equip:dateRemoved>2007-10-01T18:00Z</equip:dateRemoved>
+    <equip:notes>This antenna is located 28.5 inches nearly directly north of the antenna for a TTR-4P timing receiver.  NIMA surveyed the TTR-4P antenna location in August 1996 with the following results - 38 Degrees 48.2 N  ( 38.803107222 N) 255 Degrees 28.5 W  (255.475404583 E) 1911.087 m Ellipsoid Height with a stated accuracy of +/- 30 cm (1 sigma) in each component.  The TurboRogue antenna is mounted on a tripod platform.  This antenna is a standard AOAD/M_T using a special LNA designed to have a flat group delay response at both L1 and L2.  Because of this flat group delay response the thermal sensitivity of this antenna should be much improved over the what is typically found in this antenna type. Antenna Group Delay at L1 = 23.47 NS Antenna Group Delay at L2 = 24.92 NS  Antenna cable 25-AUG-1999 to present - Andrew FSJ1-50A (35422-33 phase stabilized) 1/4 inch Superflexible Foam Dielectric Heliax -- physical length 120 feet (36.57 m), mostly run in ceiling and floor of Bldg 400; specifications - Velocity factor 0.84 DC resistance 2 to 3 ohms per 1000 foot Capacitance, 24.2 pF/foot Inductance, .061 uH/foot Loss at 1250 MHz   6.77 dB/100 foot Loss at 1500 MHz   7.47 dB/100 foot Electrical Length Change versus Temperature - 400 PPM over (-40 to 30 C) or 5.7 PPM/C => 0.02 ps/m/C  Antenna splitter - USNO specially designed antenna splitter that has > 80 db port to port isolation and flat group delay response. Antenna splitter cable - from splitter to receiver. The Antenna splitter cable is attached to a DC block and 20db PAD at the receiver input to improve impedance matching.  The measured delays through each component of the system are summarized in the table below - L1(ns)         L2(ns) ---------      --------- antenna            23.47          24.92 antenna cable     146.9  146.9 antenna splitter    6.21           6.5 cable to receiver   7.58           7.58 DC block and 20db PAD                 0.50           0.50 receiver w/ a +27.0 ns delay between on-time signal and 20MHZ.          267.4  278.6  Note - These delay have already been added to RAW psudorange data and they should not be added to any solutions.</equip:notes>
+  </gnssAntenna>
+  <gnssAntenna>
+    <equip:antennaType>AOAD/M_T        NONE</equip:antennaType>
+    <equip:serialNumber>KW5-0201</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0000</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>oriented North but not measured</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>Andrew FSJ1-50A (35422-33 phase stabilized)</equip:antennaCableType>
+    <equip:antennaCableLength>36.57</equip:antennaCableLength>
+    <equip:dateInstalled>2007-10-01T18:35Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes>This antenna is located 28.5 inches nearly directly north of the antenna for a TTR-4P timing receiver.  NIMA surveyed the TTR-4P antenna location in August 1996 with the following results - 38 Degrees 48.2 N  ( 38.803107222 N) 255 Degrees 28.5 W  (255.475404583 E) 1911.087 m Ellipsoid Height with a stated accuracy of +/- 30 cm (1 sigma) in each component.  The TurboRogue antenna is mounted on a tripod platform.  This antenna is a standard AOAD/M_T using a special LNA designed to have a flat group delay response at both L1 and L2.  Because of this flat group delay response the thermal sensitivity of this antenna should be much improved over the what is typically found in this antenna type. Antenna Group Delay at L1 = 25.13 NS Antenna Group Delay at L2 = 25.45 NS  Antenna cable 25-AUG-1999 to present - Andrew FSJ1-50A (35422-33 phase stabilized) 1/4 inch Superflexible Foam Dielectric Heliax -- physical length 120 feet (36.57 m), mostly run in ceiling and floor of Bldg 400; specifications - Velocity factor 0.84 DC resistance 2 to 3 ohms per 1000 foot Capacitance, 24.2 pF/foot Inductance, .061 uH/foot Loss at 1250 MHz   6.77 dB/100 foot Loss at 1500 MHz   7.47 dB/100 foot Electrical Length Change versus Temperature - 400 PPM over (-40 to 30 C) or 5.7 PPM/C => 0.02 ps/m/C  Antenna splitter - USNO specially designed antenna splitter that has > 80 db port to port isolation and flat group delay response. While troubleshooting, the splitter was replaced on 9/26/07T21 was noticed. Antenna splitter cable - from splitter to receiver. The Antenna splitter cable is attached to a DC block and 20db PAD at the receiver input to improve impedance matching.  The measured delays through each component of the system are summarized in the table below -  L1(ns)         L2(ns) ---------      --------- antenna            25.13          25.45 antenna cable     146.9  146.9 antenna splitter    7.83           7.96 cable to receiver   7.58           7.58 DC block and 20db PAD                 0.50           0.50 receiver w/ a +27.0 ns delay between on-time signal and 20MHZ.          267.4  278.6  Note - These delays have already been added to RAW psudorange data and they should not be added to any solutions.</equip:notes>
+  </gnssAntenna>
+  <frequencyStandard>
+    <equip:standardType>H-MASER</equip:standardType>
+    <equip:inputFrequency>5 MHz</equip:inputFrequency>
+    <equip:effectiveDates>1998-03-24/CCYY-MM-DD</equip:effectiveDates>
+    <equip:notes>reference signal from USNO Alternate Master Clock #1, the back-up realization of UTC(USNO) via two-way satellite time transfer; All calibration delays have already been accounted for in the RAW pseudorange data produced by AMC2.</equip:notes>
+  </frequencyStandard>
+  <collocationInformation>
+    <equip:instrumentType>none</equip:instrumentType>
+    <equip:status></equip:status>
+    <equip:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</equip:effectiveDates>
+    <equip:notes></equip:notes>
+  </collocationInformation>
+  <humiditySensor>
+    <equip:type>HUMICA H-sensor (pn 16663)</equip:type>
+    <equip:manufacturer>Vaisala</equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2002-02-28/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval>15 seconds</equip:dataSamplingInterval>
+    <equip:accuracy-percentRelativeHumidity>+/-1%(0...90%RH)</equip:accuracy-percentRelativeHumidity>
+    <equip:aspiration>(UNASPIRATED/NATURAL/FAN/etc)</equip:aspiration>
+    <equip:notes>+/-2%(90...100%RH) NOAA GSOS # 064 Horizontal offset from GPS 527 m Vertical offset from GPS ~29 m</equip:notes>
+  </humiditySensor>
+  <pressureSensor>
+    <equip:type>PTB220</equip:type>
+    <equip:manufacturer>Vaisala</equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna>~29</equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2002-02-28/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval>15 seconds</equip:dataSamplingInterval>
+    <equip:accuracy-hPa>+/-0.1</equip:accuracy-hPa>
+    <equip:notes>NOAA GSOS # 064 Horizontal offset from GPS ~527 m Vertical offset from GPS ~29 m</equip:notes>
+  </pressureSensor>
+  <temperatureSensor>
+    <equip:type>PT100 RTD 1/s DIN 43760B</equip:type>
+    <equip:manufacturer>Vaisala</equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2002-02-28/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval>15 seconds</equip:dataSamplingInterval>
+    <equip:accuracy-degreesCelcius>+/-0.1 @ 20.0C</equip:accuracy-degreesCelcius>
+    <equip:aspiration>(UNASPIRATED/NATURAL/FAN/etc)</equip:aspiration>
+    <equip:notes>NOAA GSOS # 064 Horizontal offset from GPS ~527 m Vertical offset from GPS ~29 m</equip:notes>
+  </temperatureSensor>
+  <waterVaporSensor>
+    <equip:type>none</equip:type>
+    <equip:manufacturer></equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>CCYY-MM-DD/CCYY-MM-DD</equip:effectiveDates>
+    <equip:distanceToAntenna></equip:distanceToAntenna>
+    <equip:notes>(multiple lines)</equip:notes>
+  </waterVaporSensor>
+  <localEpisodicEvents>
+    <li:date>2013-03-11</li:date>
+    <li:event>Computer replaced. There was a data outage</li:event>
+  </localEpisodicEvents>
+  <contactAgency>
+    <contact:agency>U.S. Naval Observatory, Alternate Master Clock</contact:agency>
+    <contact:preferredAbbreviation>USNO/AMC</contact:preferredAbbreviation>
+    <contact:mailingAddress>USNO/AMC</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name>Bill Bollwerk</contact:name>
+      <contact:telephonePrimary>719-567-6740</contact:telephonePrimary>
+      <contact:telephoneSecondary>202-359-6011</contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail>bill.bollwerk@usno.navy.mil</contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>Ed Powers (USNO)</contact:name>
+      <contact:telephonePrimary>202-762-1451</contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax>202-762-1511</contact:fax>
+      <contact:e-mail>edward.powers@usno.navy.mil</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>400 O'Malley Ave, Suite 44 Schriever AFB, CO 80912-4044 Regional Data Center is JPL  Dave Stowers (JPL) 818-354-7055  818-393-4965 dstowers@jpl.nasa.gov</contact:notes>
+  </contactAgency>
+  <responsibleAgency>
+    <contact:agency>U.S. Naval Observatory</contact:agency>
+    <contact:preferredAbbreviation>USNO</contact:preferredAbbreviation>
+    <contact:mailingAddress>Time Service Department</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>Francine Vannicola(USNO)</contact:name>
+      <contact:telephonePrimary>202-762-1455</contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax>202-762-1511</contact:fax>
+      <contact:e-mail>francine.vannicola@usno.navy.mil</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>3450 Massachusetts Ave., NW Wasington, D.C. 20392-5420 (multiple lines)</contact:notes>
+  </responsibleAgency>
+  <moreInformation>
+    <mi:primaryDataCenter></mi:primaryDataCenter>
+    <mi:secondaryDataCenter></mi:secondaryDataCenter>
+    <mi:urlForMoreInformation></mi:urlForMoreInformation>
+    <mi:hardCopyOnFile/>
+    <mi:siteMap>N</mi:siteMap>
+    <mi:siteDiagram>N</mi:siteDiagram>
+    <mi:horizonMask>N</mi:horizonMask>
+    <mi:monumentDescription></mi:monumentDescription>
+    <mi:sitePictures>N</mi:sitePictures>
+    <mi:notes>(multiple lines)</mi:notes>
+    <mi:antennaGraphicsWithDimensions/>
+    <mi:insertTextGraphicFromAntenna/>
+  </moreInformation>
+</igsSiteLog>

--- a/src/test/resources/sitelog/testData/ARTU.xml
+++ b/src/test/resources/sitelog/testData/ARTU.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<igsSiteLog xmlns="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004" xmlns:contact="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/contact/2004" xmlns:equip="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004" xmlns:li="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004" xmlns:mi="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004  http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004/igsSiteLog.xsd"><!--Alice Springs Station Log-->
+<!--Version 0.01-->
+<!--Geoscience Australia Geodesy-->
+<!--For More Information regarding XML based Site Logs go to-->
+<!--http://sopac.ucsd.edu/projects/xml-->
+
+  <formInformation>
+    <mi:preparedBy>David Maggert</mi:preparedBy>
+    <mi:datePrepared>2013-01-31</mi:datePrepared>
+    <mi:reportType>UPDATE</mi:reportType>
+    <mi:previousLog>artu_20000214.log</mi:previousLog>
+    <mi:modifiedSections>10.1</mi:modifiedSections>
+  </formInformation>
+  <siteIdentification>
+    <mi:siteName>Arti</mi:siteName>
+    <mi:fourCharacterID>ARTU</mi:fourCharacterID>
+    <mi:monumentInscription>(none)</mi:monumentInscription>
+    <mi:iersDOMESNumber>12362M001</mi:iersDOMESNumber>
+    <mi:cdpNumber>(A4)</mi:cdpNumber>
+    <mi:monumentDescription>(PILLAR/BRASS PLATE/STEEL MAST/etc)</mi:monumentDescription>
+    <mi:heightOfTheMonument></mi:heightOfTheMonument>
+    <mi:monumentFoundation>(STEEL RODS, CONCRETE BLOCK, ROOF, etc)</mi:monumentFoundation>
+    <mi:foundationDepth></mi:foundationDepth>
+    <mi:markerDescription>(CHISELLED CROSS/DIVOT/BRASS NAIL/etc)</mi:markerDescription>
+    <mi:dateInstalled>1999-08-06</mi:dateInstalled>
+    <mi:geologicCharacteristic>Pre-Uralian foredeep</mi:geologicCharacteristic>
+    <mi:bedrockType>Accretionary complex</mi:bedrockType>
+    <mi:bedrockCondition>Jointed</mi:bedrockCondition>
+    <mi:fractureSpacing>Over 200 cm</mi:fractureSpacing>
+    <mi:faultZonesNearby>(YES/NO/Name of the zone)</mi:faultZonesNearby>
+    <mi:distance-Activity>(multiple lines)</mi:distance-Activity>
+    <mi:notes>Arti is located about 150 km to the west of the Main Uralian fault dividing Europe and Asia.  This station is part of NEDA Deformation Array created and run by RUSEG by GPS Technology. NEDA operational control is provided by RDAAC Acquisition/Analysis Center (Moscow). RDAAC is also IGS Operational Center for NEDA. RUSEG is a collaborative project of Lamont- Doherty Earth Observatory and Russian Academy of Sciences supported through the IRIS Consortium and JPL.  The GPS reference mark consists of 5/8-11" diameter, vertical rod of the stainless steel. The rod is glued into the flat roof of Geophysical Observatory Arti. The Observatory belongs to Institute of Geophysics, the Urals Division of Russian Academy of Sci. The roof is made of the reinforced concrete. The 1-floor building is made of bricks. Vertical datum of the rod. The antenna is attached to the rod with UNAVCO compact leveling mount. The antenna and the choke-ring assembly are protected with the JPL hemispherical radome.</mi:notes>
+  </siteIdentification>
+  <siteLocation>
+    <mi:city>Arti</mi:city>
+    <mi:state>Ekaterinburg region</mi:state>
+    <mi:country>Russian Federation</mi:country>
+    <mi:tectonicPlate>Eurasia</mi:tectonicPlate>
+    <approximatePositionITRF>
+      <mi:xCoordinateInMeters>1843956.968</mi:xCoordinateInMeters>
+      <mi:yCoordinateInMeters>3016202.970</mi:yCoordinateInMeters>
+      <mi:zCoordinateInMeters>5291261.660</mi:zCoordinateInMeters>
+      <mi:latitude-North>+562547.36</mi:latitude-North>
+      <mi:longitude-East>+0583337.63</mi:longitude-East>
+      <mi:elevation-m_ellips.>247.511</mi:elevation-m_ellips.>
+    </approximatePositionITRF>
+    <mi:notes>GAMIT Solution ITRF94. Epoch 1996.5845</mi:notes>
+  </siteLocation>
+  <gnssReceiver>
+    <equip:receiverType>ASHTECH Z-XII3</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>LP03316</equip:serialNumber>
+    <equip:firmwareVersion>NAV CC00 CH 1D02</equip:firmwareVersion>
+    <equip:elevationCutoffSetting></equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-08-05T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>(none or tolerance in degrees C)</equip:temperatureStabilization>
+    <equip:notes>Model 700845-10F (Z-12 CGRS)</equip:notes>
+  </gnssReceiver>
+  <gnssAntenna>
+    <equip:antennaType>ASH700936D_M    DOME</equip:antennaType>
+    <equip:serialNumber>CR13077</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0796</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>DOME</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength></equip:antennaCableLength>
+    <equip:dateInstalled>1999-08-06T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes>Antenna Diagram below</equip:notes>
+  </gnssAntenna>
+  <surveyedLocalTies>
+    <equip:tiedMarkerName>ARTB</equip:tiedMarkerName>
+    <equip:tiedMarkerUsage>(SLR/VLBI/LOCAL CONTROL/FOOTPRINT/etc)</equip:tiedMarkerUsage>
+    <equip:tiedMarkerCDPNumber></equip:tiedMarkerCDPNumber>
+    <equip:tiedMarkerDOMESNumber></equip:tiedMarkerDOMESNumber>
+    <equip:differentialComponentsGNSSMarkerToTiedMonumentsITRS>
+      <equip:dX>-72.608</equip:dX>
+      <equip:dY>-4.469</equip:dY>
+      <equip:dZ>26.138</equip:dZ>
+    </equip:differentialComponentsGNSSMarkerToTiedMonumentsITRS>
+    <equip:localSiteTiesAccuracy>1 mm</equip:localSiteTiesAccuracy>
+    <equip:surveyMethod>(GPS CAMPAIGN/TRILATERATION/TRIANGULATION/etc)</equip:surveyMethod>
+    <equip:dateMeasured>1999-10-01</equip:dateMeasured>
+    <equip:notes>GAMIT solution of simultaneous GPS observations (baseline mode in sestbl.).</equip:notes>
+  </surveyedLocalTies>
+  <frequencyStandard>
+    <equip:standardType>INTERNAL</equip:standardType>
+    <equip:inputFrequency></equip:inputFrequency>
+    <equip:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</equip:effectiveDates>
+    <equip:notes>(multiple lines)</equip:notes>
+  </frequencyStandard>
+  <humiditySensor>
+    <equip:type></equip:type>
+    <equip:manufacturer></equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>CCYY-MM-DD/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval></equip:dataSamplingInterval>
+    <equip:accuracy-percentRelativeHumidity>(% rel h)</equip:accuracy-percentRelativeHumidity>
+    <equip:aspiration>(UNASPIRATED/NATURAL/FAN/etc)</equip:aspiration>
+    <equip:notes>(multiple lines)</equip:notes>
+  </humiditySensor>
+  <pressureSensor>
+    <equip:type></equip:type>
+    <equip:manufacturer></equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>CCYY-MM-DD/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval></equip:dataSamplingInterval>
+    <equip:accuracy-hPa>(mbar)</equip:accuracy-hPa>
+    <equip:notes>(multiple lines)</equip:notes>
+  </pressureSensor>
+  <temperatureSensor>
+    <equip:type></equip:type>
+    <equip:manufacturer></equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>CCYY-MM-DD/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval></equip:dataSamplingInterval>
+    <equip:accuracy-degreesCelcius>(deg C)</equip:accuracy-degreesCelcius>
+    <equip:aspiration>(UNASPIRATED/NATURAL/FAN/etc)</equip:aspiration>
+    <equip:notes>(multiple lines)</equip:notes>
+  </temperatureSensor>
+  <waterVaporSensor>
+    <equip:type></equip:type>
+    <equip:manufacturer></equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>CCYY-MM-DD/CCYY-MM-DD</equip:effectiveDates>
+    <equip:distanceToAntenna></equip:distanceToAntenna>
+    <equip:notes>(multiple lines)</equip:notes>
+  </waterVaporSensor>
+  <localEpisodicEvents>
+    <li:date>2012-02-07</li:date>
+    <li:event>Transition from .soc to .ash data types.</li:event>
+  </localEpisodicEvents>
+  <contactAgency>
+    <contact:agency>Geophysical Observatory Arti</contact:agency>
+    <contact:preferredAbbreviation></contact:preferredAbbreviation>
+    <contact:mailingAddress>2A Geofizicheskaya ul.</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name>Oleg Kusonskiy</contact:name>
+      <contact:telephonePrimary>+7 343-952-1638 work</contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail>zavlab@aru.gssc.rssi.ru</contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>Mikhail Kogan</contact:name>
+      <contact:telephonePrimary>+1 914 365-8882</contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax>+1 914 365-8150</contact:fax>
+      <contact:e-mail>kogan@ldeo.columbia.edu</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>623350 Arti Ekaterinburg Region, RUSSIA (multiple lines)</contact:notes>
+  </contactAgency>
+  <responsibleAgency>
+    <contact:agency>RDAAC/JPL/IRIS</contact:agency>
+    <contact:preferredAbbreviation></contact:preferredAbbreviation>
+    <contact:mailingAddress>6-3 Universitetskiy Prospect</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>117333 Moscow, RUSSIA (multiple lines)</contact:notes>
+  </responsibleAgency>
+  <moreInformation>
+    <mi:primaryDataCenter>http</mi:primaryDataCenter>
+    <mi:secondaryDataCenter>http</mi:secondaryDataCenter>
+    <mi:urlForMoreInformation>http</mi:urlForMoreInformation>
+    <mi:hardCopyOnFile/>
+    <mi:siteMap>(Y or URL)</mi:siteMap>
+    <mi:siteDiagram>(Y)</mi:siteDiagram>
+    <mi:horizonMask>(Y)</mi:horizonMask>
+    <mi:monumentDescription></mi:monumentDescription>
+    <mi:sitePictures>(Y)</mi:sitePictures>
+    <mi:notes>Hardcopy Information available from Responsible Agency</mi:notes>
+    <mi:antennaGraphicsWithDimensions/>
+    <mi:insertTextGraphicFromAntenna/>
+  </moreInformation>
+</igsSiteLog>

--- a/src/test/resources/sitelog/testData/CRAO.xml
+++ b/src/test/resources/sitelog/testData/CRAO.xml
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<igsSiteLog xmlns="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004" xmlns:contact="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/contact/2004" xmlns:equip="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004" xmlns:li="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004" xmlns:mi="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004  http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004/igsSiteLog.xsd"><!--Alice Springs Station Log-->
+<!--Version 0.01-->
+<!--Geoscience Australia Geodesy-->
+<!--For More Information regarding XML based Site Logs go to-->
+<!--http://sopac.ucsd.edu/projects/xml-->
+
+  <formInformation>
+    <mi:preparedBy>David Maggert</mi:preparedBy>
+    <mi:datePrepared>2013-01-31</mi:datePrepared>
+    <mi:reportType>UPDATE</mi:reportType>
+    <mi:previousLog>crao_20090415.log</mi:previousLog>
+    <mi:modifiedSections>10.1, 12</mi:modifiedSections>
+  </formInformation>
+  <siteIdentification>
+    <mi:siteName>Crimean Astrophysical Observatory</mi:siteName>
+    <mi:fourCharacterID>CRAO</mi:fourCharacterID>
+    <mi:monumentInscription></mi:monumentInscription>
+    <mi:iersDOMESNumber>12337M002</mi:iersDOMESNumber>
+    <mi:cdpNumber></mi:cdpNumber>
+    <mi:monumentDescription>IRON PIPE filled with concrete</mi:monumentDescription>
+    <mi:heightOfTheMonument>4.5</mi:heightOfTheMonument>
+    <mi:monumentFoundation>CONCRETE BLOCK</mi:monumentFoundation>
+    <mi:foundationDepth>1.5</mi:foundationDepth>
+    <mi:markerDescription>DIVOT in STAINLESS STEEL PIN in concrete</mi:markerDescription>
+    <mi:dateInstalled>2000-04-27</mi:dateInstalled>
+    <mi:geologicCharacteristic>BEDROCK</mi:geologicCharacteristic>
+    <mi:bedrockType>SEDIMENTARY</mi:bedrockType>
+    <mi:bedrockCondition>(FRESH/JOINTED/WEATHERED)</mi:bedrockCondition>
+    <mi:fractureSpacing>51-200 cm</mi:fractureSpacing>
+    <mi:faultZonesNearby>YES</mi:faultZonesNearby>
+    <mi:distance-Activity>30 km/underwater.</mi:distance-Activity>
+    <mi:notes>Concrete filled iron pipe is 40 cm in diameter, and is anchored to a 2x2x1.5m concrete pad set in bedrock. The iron pipe monument extends 4.5 m above the pad.</mi:notes>
+  </siteIdentification>
+  <siteLocation>
+    <mi:city>Simeiz</mi:city>
+    <mi:state></mi:state>
+    <mi:country>Ukraine</mi:country>
+    <mi:tectonicPlate>Eurasia</mi:tectonicPlate>
+    <approximatePositionITRF>
+      <mi:xCoordinateInMeters>3783897.0146</mi:xCoordinateInMeters>
+      <mi:yCoordinateInMeters>2551404.4833</mi:yCoordinateInMeters>
+      <mi:zCoordinateInMeters>4441264.3100</mi:zCoordinateInMeters>
+      <mi:latitude-North>+442447.74</mi:latitude-North>
+      <mi:longitude-East>+0335927.54</mi:longitude-East>
+      <mi:elevation-m_ellips.>365.8</mi:elevation-m_ellips.>
+    </approximatePositionITRF>
+    <mi:notes></mi:notes>
+  </siteLocation>
+  <gnssReceiver>
+    <equip:receiverType>ROGUE SNR-8000</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>T315</equip:serialNumber>
+    <equip:firmwareVersion>3.2.32.8</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2000-04-27T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2004-08-02T00:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ROGUE SNR-8000</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>T362</equip:serialNumber>
+    <equip:firmwareVersion>3.2.32.11</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2004-08-02T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2008-05-26T23:59Z</equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ASHTECH UZ-12</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>UC120031621</equip:serialNumber>
+    <equip:firmwareVersion>CQ00</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2009-03-04T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssReceiver>
+  <gnssAntenna>
+    <equip:antennaType>AOAD/M_T        SCIS</equip:antennaType>
+    <equip:serialNumber>386</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0800</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>SCIS</equip:antennaRadomeType>
+    <equip:radomeSerialNumber>139</equip:radomeSerialNumber>
+    <equip:antennaCableType>AOA p/n 7490045</equip:antennaCableType>
+    <equip:antennaCableLength>10</equip:antennaCableLength>
+    <equip:dateInstalled>2000-04-27T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2008-05-26T23:59Z</equip:dateRemoved>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssAntenna>
+  <gnssAntenna>
+    <equip:antennaType>ASH701945C_M    SCIS</equip:antennaType>
+    <equip:serialNumber>CR520003501</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0800</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>SCIS</equip:antennaRadomeType>
+    <equip:radomeSerialNumber>139</equip:radomeSerialNumber>
+    <equip:antennaCableType>LMR 400</equip:antennaCableType>
+    <equip:antennaCableLength>10</equip:antennaCableLength>
+    <equip:dateInstalled>2009-03-04T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssAntenna>
+  <surveyedLocalTies>
+    <equip:tiedMarkerName>SIML</equip:tiedMarkerName>
+    <equip:tiedMarkerUsage>SLR</equip:tiedMarkerUsage>
+    <equip:tiedMarkerCDPNumber>1873</equip:tiedMarkerCDPNumber>
+    <equip:tiedMarkerDOMESNumber>12337S003</equip:tiedMarkerDOMESNumber>
+    <equip:differentialComponentsGNSSMarkerToTiedMonumentsITRS>
+      <equip:dX>5.034</equip:dX>
+      <equip:dY>0.555</equip:dY>
+      <equip:dZ>-6.895</equip:dZ>
+    </equip:differentialComponentsGNSSMarkerToTiedMonumentsITRS>
+    <equip:localSiteTiesAccuracy>(mm)</equip:localSiteTiesAccuracy>
+    <equip:surveyMethod>TRIANGULATION</equip:surveyMethod>
+    <equip:dateMeasured>2003-08-01T00:00Z</equip:dateMeasured>
+    <equip:notes>(multiple lines)</equip:notes>
+  </surveyedLocalTies>
+  <frequencyStandard>
+    <equip:standardType>INTERNAL</equip:standardType>
+    <equip:inputFrequency>       Input Frequency        :</equip:inputFrequency>
+    <equip:effectiveDates>2000-04-27/CCYY-MM-DD</equip:effectiveDates>
+    <equip:notes>(multiple lines)</equip:notes>
+  </frequencyStandard>
+  <collocationInformation>
+    <equip:instrumentType>SLR  </equip:instrumentType>
+    <equip:status>PERMANENT</equip:status>
+    <equip:effectiveDates>1988-05-01/CCYY-MM-DD</equip:effectiveDates>
+    <equip:notes>SIML, 1873</equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>SLR  </equip:instrumentType>
+    <equip:status>PERMANENT</equip:status>
+    <equip:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</equip:effectiveDates>
+    <equip:notes>Katzively 1893</equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>VLBI  </equip:instrumentType>
+    <equip:status>PERMANENT</equip:status>
+    <equip:effectiveDates>1969-01-01/CCYY-MM-DD</equip:effectiveDates>
+    <equip:notes>RT22 7332</equip:notes>
+  </collocationInformation>
+  <humiditySensor>
+    <equip:type>THGR918N</equip:type>
+    <equip:manufacturer>Oregon Scientific</equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna>0</equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2004-01-10/2008-05-26</equip:effectiveDates>
+    <equip:dataSamplingInterval>30</equip:dataSamplingInterval>
+    <equip:accuracy-percentRelativeHumidity>1</equip:accuracy-percentRelativeHumidity>
+    <equip:aspiration>(UNASPIRATED/NATURAL/FAN/etc)</equip:aspiration>
+    <equip:notes>(multiple lines)</equip:notes>
+  </humiditySensor>
+  <humiditySensor>
+    <equip:type>Capacitance Probe</equip:type>
+    <equip:manufacturer>Paroscientific</equip:manufacturer>
+    <equip:serialNumber>73589</equip:serialNumber>
+    <equip:heightDiffToAntenna>0</equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2009-03-04/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval>1 minute</equip:dataSamplingInterval>
+    <equip:accuracy-percentRelativeHumidity>+/- 2</equip:accuracy-percentRelativeHumidity>
+    <equip:aspiration>NATURAL</equip:aspiration>
+    <equip:notes>(multiple lines)</equip:notes>
+  </humiditySensor>
+  <pressureSensor>
+    <equip:type>BTHR918N</equip:type>
+    <equip:manufacturer>Oregon Scientific</equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna>0</equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2004-01-10/2008-05-26</equip:effectiveDates>
+    <equip:dataSamplingInterval>30</equip:dataSamplingInterval>
+    <equip:accuracy-hPa>1 mbar</equip:accuracy-hPa>
+    <equip:notes>(multiple lines)</equip:notes>
+  </pressureSensor>
+  <pressureSensor>
+    <equip:type>Digiquartz Barometric Standard</equip:type>
+    <equip:manufacturer>Paroscientific</equip:manufacturer>
+    <equip:serialNumber>73589</equip:serialNumber>
+    <equip:heightDiffToAntenna>0</equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2009-03-04/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval>1 minute</equip:dataSamplingInterval>
+    <equip:accuracy-hPa>0.010%</equip:accuracy-hPa>
+    <equip:notes>(multiple lines)</equip:notes>
+  </pressureSensor>
+  <temperatureSensor>
+    <equip:type>THGR918N</equip:type>
+    <equip:manufacturer>Oregon Scientific</equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna>0</equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2004-01-10/2008-05-26</equip:effectiveDates>
+    <equip:dataSamplingInterval>30</equip:dataSamplingInterval>
+    <equip:accuracy-degreesCelcius>1 deg C</equip:accuracy-degreesCelcius>
+    <equip:aspiration>(UNASPIRATED/NATURAL/FAN/etc)</equip:aspiration>
+    <equip:notes>(multiple lines)</equip:notes>
+  </temperatureSensor>
+  <temperatureSensor>
+    <equip:type>Platinum Resistance Temperature Probe</equip:type>
+    <equip:manufacturer>Paroscientific</equip:manufacturer>
+    <equip:serialNumber>73589</equip:serialNumber>
+    <equip:heightDiffToAntenna>0</equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2009-03-04/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval>1 minute</equip:dataSamplingInterval>
+    <equip:accuracy-degreesCelcius>0.5 deg C</equip:accuracy-degreesCelcius>
+    <equip:aspiration>NATURAL</equip:aspiration>
+    <equip:notes>(multiple lines)</equip:notes>
+  </temperatureSensor>
+  <radioInterferences>
+    <li:possibleProblemSources>CELL PHONE ANTENNA</li:possibleProblemSources>
+    <li:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</li:effectiveDates>
+    <li:observedDegredation></li:observedDegredation>
+    <li:notes>(multiple lines)</li:notes>
+  </radioInterferences>
+  <localEpisodicEvents>
+    <li:date>2012-02-07</li:date>
+    <li:event>Transitioned from .soc to .ash data types.  For</li:event>
+  </localEpisodicEvents>
+  <contactAgency>
+    <contact:agency>Crimean Astrophysical Observatory</contact:agency>
+    <contact:preferredAbbreviation>CRAO</contact:preferredAbbreviation>
+    <contact:mailingAddress>Nauchny, Crimea</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name>Dmytrotsa Andrew</contact:name>
+      <contact:telephonePrimary>+38-0654-240-370</contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail>dmytrotsa@gmail.com</contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>Robert Reilinger</contact:name>
+      <contact:telephonePrimary>617-253-7860</contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax>617-253-6385</contact:fax>
+      <contact:e-mail>reilinge@erl.mit.edu</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>334413, Ukraine (multiple lines)</contact:notes>
+  </contactAgency>
+  <responsibleAgency>
+    <contact:agency>UNAVCO, Inc.</contact:agency>
+    <contact:preferredAbbreviation>UNAVCO</contact:preferredAbbreviation>
+    <contact:mailingAddress>6350 Nautilus Drive</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>Boulder, CO 80301 </contact:notes>
+  </responsibleAgency>
+  <moreInformation>
+    <mi:primaryDataCenter></mi:primaryDataCenter>
+    <mi:secondaryDataCenter></mi:secondaryDataCenter>
+    <mi:urlForMoreInformation></mi:urlForMoreInformation>
+    <mi:hardCopyOnFile/>
+    <mi:siteMap>Y</mi:siteMap>
+    <mi:siteDiagram>Y</mi:siteDiagram>
+    <mi:horizonMask>Y</mi:horizonMask>
+    <mi:monumentDescription></mi:monumentDescription>
+    <mi:sitePictures>Y</mi:sitePictures>
+    <mi:notes>(multiple lines)</mi:notes>
+    <mi:antennaGraphicsWithDimensions/>
+    <mi:insertTextGraphicFromAntenna/>
+  </moreInformation>
+</igsSiteLog>

--- a/src/test/resources/sitelog/testData/CRO1.xml
+++ b/src/test/resources/sitelog/testData/CRO1.xml
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<igsSiteLog xmlns="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004" xmlns:contact="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/contact/2004" xmlns:equip="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004" xmlns:li="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004" xmlns:mi="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004  http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004/igsSiteLog.xsd"><!--Alice Springs Station Log-->
+<!--Version 0.01-->
+<!--Geoscience Australia Geodesy-->
+<!--For More Information regarding XML based Site Logs go to-->
+<!--http://sopac.ucsd.edu/projects/xml-->
+
+  <formInformation>
+    <mi:preparedBy>David Maggert</mi:preparedBy>
+    <mi:datePrepared>2013-01-31</mi:datePrepared>
+    <mi:reportType>UPDATE</mi:reportType>
+    <mi:previousLog>cro1_20110624.log</mi:previousLog>
+    <mi:modifiedSections>10.1, 12</mi:modifiedSections>
+  </formInformation>
+  <siteIdentification>
+    <mi:siteName>St. Croix VLBA</mi:siteName>
+    <mi:fourCharacterID>CRO1</mi:fourCharacterID>
+    <mi:monumentInscription>St. Croix VLBA RM 1</mi:monumentInscription>
+    <mi:iersDOMESNumber>43201M001</mi:iersDOMESNumber>
+    <mi:cdpNumber>JPL 4023</mi:cdpNumber>
+    <mi:monumentDescription>PILLAR</mi:monumentDescription>
+    <mi:heightOfTheMonument>0.635</mi:heightOfTheMonument>
+    <mi:monumentFoundation>(STEEL RODS, CONCRETE BLOCK, ROOF, etc)</mi:monumentFoundation>
+    <mi:foundationDepth></mi:foundationDepth>
+    <mi:markerDescription>Stainless steel plate</mi:markerDescription>
+    <mi:dateInstalled>1994-01-16</mi:dateInstalled>
+    <mi:geologicCharacteristic>(BEDROCK/CLAY/CONGLOMERATE/GRAVEL/SAND/etc)</mi:geologicCharacteristic>
+    <mi:bedrockType>(IGNEOUS/METAMORPHIC/SEDIMENTARY)</mi:bedrockType>
+    <mi:bedrockCondition>(FRESH/JOINTED/WEATHERED)</mi:bedrockCondition>
+    <mi:fractureSpacing>(1-10 cm/10-50 cm/50-200 cm/over 200 cm)</mi:fractureSpacing>
+    <mi:faultZonesNearby>(YES/NO/Name of the zone)</mi:faultZonesNearby>
+    <mi:distance-Activity>(multiple lines)</mi:distance-Activity>
+    <mi:notes>(multiple lines) The monument is a 0.457m diameter stainless steel plate set in a 0.762m diameter monolith that projects 0.635m above grade. The monument is located approximately 82m northwest of the 25m VLBA antenna.</mi:notes>
+  </siteIdentification>
+  <siteLocation>
+    <mi:city>Christiansted</mi:city>
+    <mi:state></mi:state>
+    <mi:country>U.S. Virgin Islands (USA)</mi:country>
+    <mi:tectonicPlate>Caribbean</mi:tectonicPlate>
+    <approximatePositionITRF>
+      <mi:xCoordinateInMeters>2607771.2183</mi:xCoordinateInMeters>
+      <mi:yCoordinateInMeters>-5488076.6919</mi:yCoordinateInMeters>
+      <mi:zCoordinateInMeters>1932767.7873</mi:zCoordinateInMeters>
+      <mi:latitude-North>+174524.8335</mi:latitude-North>
+      <mi:longitude-East>-0643503.5511</mi:longitude-East>
+      <mi:elevation-m_ellips.>-31.9558</mi:elevation-m_ellips.>
+    </approximatePositionITRF>
+    <mi:notes>The site is located at the NRAO VLBA on the northeast tip of St. Croix.</mi:notes>
+  </siteLocation>
+  <gnssReceiver>
+    <equip:receiverType>ROGUE SNR-8000</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>T133</equip:serialNumber>
+    <equip:firmwareVersion>2.8</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1994-01-16T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1995-10-13T00:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ROGUE SNR-8000</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>T356</equip:serialNumber>
+    <equip:firmwareVersion>3.2 link 03/09/95</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1995-10-13T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-09-30T17:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>AOA SNR-8100 ACT</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>R141</equip:serialNumber>
+    <equip:firmwareVersion>3.3.32.2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-09-30T17:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2000-04-14T00:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>AOA SNR-8100 ACT</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>R141</equip:serialNumber>
+    <equip:firmwareVersion>3.3.32.2 1s soc2rnx</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2000-04-14T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2000-11-14T00:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>samplerate - 1s offload format - soc conversion to 30s - soc2rnx</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ASHTECH Z-XII3</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>LP020003804</equip:serialNumber>
+    <equip:firmwareVersion>CDOO 1s soc2rnx</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2000-11-14T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2001-05-25T00:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>samplerate - 1s offload format - soc conversion to 30s - soc2rnx</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ASHTECH Z-XII3</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>LP020004507</equip:serialNumber>
+    <equip:firmwareVersion>CD00-1D02</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2001-05-25T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2005-01-19T00:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ASHTECH Z-XII3</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>LP03460</equip:serialNumber>
+    <equip:firmwareVersion>CD00-1D02</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2005-08-04T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2006-02-22T17:30Z</equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ASHTECH UZ-12</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>UC1200345005</equip:serialNumber>
+    <equip:firmwareVersion>CQ00</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2006-02-24T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2010-07-07T23:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ASHTECH UZ-12</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>IR2200722005</equip:serialNumber>
+    <equip:firmwareVersion>CQ00</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2010-07-08T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>none</equip:temperatureStabilization>
+    <equip:notes>NEW ACROSSER PC,APC 750XL UPS, 2X1 POWERED SPLITTER RCVR UV# 71315</equip:notes>
+  </gnssReceiver>
+  <gnssAntenna>
+    <equip:antennaType>AOAD/M_T        JPLA</equip:antennaType>
+    <equip:serialNumber>133</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0614</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>JPLA</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength></equip:antennaCableLength>
+    <equip:dateInstalled>1994-01-16T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1995-10-13T00:00Z</equip:dateRemoved>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssAntenna>
+  <gnssAntenna>
+    <equip:antennaType>AOAD/M_T        JPLA</equip:antennaType>
+    <equip:serialNumber>484</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0814</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>JPLA</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength></equip:antennaCableLength>
+    <equip:dateInstalled>1995-10-13T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2005-01-19T00:00Z</equip:dateRemoved>
+    <equip:notes>changed "BPA" to "ARP" here as they are the same in this case</equip:notes>
+  </gnssAntenna>
+  <gnssAntenna>
+    <equip:antennaType>ASH701945G_M    JPLA</equip:antennaType>
+    <equip:serialNumber>CR5200404026</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0814</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>JPLA</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>Andrews LMR600</equip:antennaCableType>
+    <equip:antennaCableLength>100</equip:antennaCableLength>
+    <equip:dateInstalled>2005-08-04T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2011-04-01T13:00Z</equip:dateRemoved>
+    <equip:notes></equip:notes>
+  </gnssAntenna>
+  <gnssAntenna>
+    <equip:antennaType>ASH701945G_M    NONE</equip:antennaType>
+    <equip:serialNumber>CR5200404026</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0814</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>LMR600</equip:antennaCableType>
+    <equip:antennaCableLength>100</equip:antennaCableLength>
+    <equip:dateInstalled>2011-04-01T13:10Z</equip:dateInstalled>
+    <equip:dateRemoved>2011-06-24T18:40Z</equip:dateRemoved>
+    <equip:notes>Radome Removed</equip:notes>
+  </gnssAntenna>
+  <gnssAntenna>
+    <equip:antennaType>ASH701945G_M    JPLA</equip:antennaType>
+    <equip:serialNumber>CR5200404026</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0814</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>JPLA</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>LMR600</equip:antennaCableType>
+    <equip:antennaCableLength>100</equip:antennaCableLength>
+    <equip:dateInstalled>2011-06-24T21:15Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes>Radome re-installed</equip:notes>
+  </gnssAntenna>
+  <frequencyStandard>
+    <equip:standardType>INTERNAL</equip:standardType>
+    <equip:inputFrequency>(if external)</equip:inputFrequency>
+    <equip:effectiveDates>1995-10-13/1999-10-08</equip:effectiveDates>
+    <equip:notes>(multiple lines)</equip:notes>
+  </frequencyStandard>
+  <frequencyStandard>
+    <equip:standardType>H-MASER</equip:standardType>
+    <equip:inputFrequency>5 MHz</equip:inputFrequency>
+    <equip:effectiveDates>1999-10-08/2000-11-14</equip:effectiveDates>
+    <equip:notes>(multiple lines)</equip:notes>
+  </frequencyStandard>
+  <frequencyStandard>
+    <equip:standardType>H-MASER</equip:standardType>
+    <equip:inputFrequency>5 MHz</equip:inputFrequency>
+    <equip:effectiveDates>2000-11-14/2002-09-06</equip:effectiveDates>
+    <equip:notes>z12 clock steering off</equip:notes>
+  </frequencyStandard>
+  <frequencyStandard>
+    <equip:standardType>INTERNAL</equip:standardType>
+    <equip:inputFrequency>(if external)</equip:inputFrequency>
+    <equip:effectiveDates>2002-09-06/2005-01-19</equip:effectiveDates>
+    <equip:notes>z12 clock steering on</equip:notes>
+  </frequencyStandard>
+  <frequencyStandard>
+    <equip:standardType>H-MASER</equip:standardType>
+    <equip:inputFrequency>5 MHz</equip:inputFrequency>
+    <equip:effectiveDates>2005-08-04/2006-02-23</equip:effectiveDates>
+    <equip:notes>5 dB attenuator inline w/ H-Maser cable</equip:notes>
+  </frequencyStandard>
+  <frequencyStandard>
+    <equip:standardType>H-MASER</equip:standardType>
+    <equip:inputFrequency>5 MHz</equip:inputFrequency>
+    <equip:effectiveDates>2006-02-24/2010-07-07</equip:effectiveDates>
+    <equip:notes>25 dB attenuator inline w/ H-Maser cable</equip:notes>
+  </frequencyStandard>
+  <frequencyStandard>
+    <equip:standardType>INTERNAL</equip:standardType>
+    <equip:inputFrequency>       Input Frequency        :</equip:inputFrequency>
+    <equip:effectiveDates>2010-07-08/2010-07-14</equip:effectiveDates>
+    <equip:notes>25 dB ATTENUATOR REMOVED, NEW 10 db ATTENUATOR INSTALLED BNC CABLES REPLACED</equip:notes>
+  </frequencyStandard>
+  <frequencyStandard>
+    <equip:standardType>INTERNAL</equip:standardType>
+    <equip:inputFrequency>       Input Frequency        :</equip:inputFrequency>
+    <equip:effectiveDates>2010-07-14/2010-07-19T17:00Z</equip:effectiveDates>
+    <equip:notes>10 db ATTENUATOR REMOVED 2010-07-14T13:03Z </equip:notes>
+  </frequencyStandard>
+  <frequencyStandard>
+    <equip:standardType>H-MASER</equip:standardType>
+    <equip:inputFrequency>5 MHz</equip:inputFrequency>
+    <equip:effectiveDates>2010-07-19T17:00Z/CCYY-MM-DD</equip:effectiveDates>
+    <equip:notes></equip:notes>
+  </frequencyStandard>
+  <collocationInformation>
+    <equip:instrumentType>VLBI</equip:instrumentType>
+    <equip:status>(PERMANENT/MOBILE)</equip:status>
+    <equip:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</equip:effectiveDates>
+    <equip:notes>(multiple lines)</equip:notes>
+  </collocationInformation>
+  <humiditySensor>
+    <equip:type></equip:type>
+    <equip:manufacturer></equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>CCYY-MM-DD/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval></equip:dataSamplingInterval>
+    <equip:accuracy-percentRelativeHumidity>(% rel h)</equip:accuracy-percentRelativeHumidity>
+    <equip:aspiration>(UNASPIRATED/NATURAL/FAN/etc)</equip:aspiration>
+    <equip:notes>(multiple lines)</equip:notes>
+  </humiditySensor>
+  <pressureSensor>
+    <equip:type></equip:type>
+    <equip:manufacturer></equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>CCYY-MM-DD/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval></equip:dataSamplingInterval>
+    <equip:accuracy-hPa>(mbar)</equip:accuracy-hPa>
+    <equip:notes>(multiple lines)</equip:notes>
+  </pressureSensor>
+  <temperatureSensor>
+    <equip:type></equip:type>
+    <equip:manufacturer></equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>CCYY-MM-DD/CCYY-MM-DD</equip:effectiveDates>
+    <equip:dataSamplingInterval></equip:dataSamplingInterval>
+    <equip:accuracy-degreesCelcius>(deg C)</equip:accuracy-degreesCelcius>
+    <equip:aspiration>(UNASPIRATED/NATURAL/FAN/etc)</equip:aspiration>
+    <equip:notes>(multiple lines)</equip:notes>
+  </temperatureSensor>
+  <waterVaporSensor>
+    <equip:type></equip:type>
+    <equip:manufacturer></equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>CCYY-MM-DD/CCYY-MM-DD</equip:effectiveDates>
+    <equip:distanceToAntenna></equip:distanceToAntenna>
+    <equip:notes>(multiple lines)</equip:notes>
+  </waterVaporSensor>
+  <localEpisodicEvents>
+    <li:date>2012-02-03</li:date>
+    <li:event>Transitioned from .soc to .ash data types.  For</li:event>
+  </localEpisodicEvents>
+  <contactAgency>
+    <contact:agency>National Radio Astronomy Observatory (NRAO)</contact:agency>
+    <contact:preferredAbbreviation>NRAO</contact:preferredAbbreviation>
+    <contact:mailingAddress>NRAO St. Croix VLBA Station</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name>Pete Allen/Greg Worrell</contact:name>
+      <contact:telephonePrimary>(340) 773-4448</contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail>scvlba@aoc.nrao.edu</contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>Paul Rhodes</contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail>prhodes@aoc.nrao.edu</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>P.O. Box 24878 Gallows Bay Station, Christiansted St. Croix, USVI  00824-0878 pallen@nrao.edu gworrell@nrao.edu (multiple lines)</contact:notes>
+  </contactAgency>
+  <responsibleAgency>
+    <contact:agency>Jet Propulsion Laboratory</contact:agency>
+    <contact:preferredAbbreviation>JPL</contact:preferredAbbreviation>
+    <contact:mailingAddress>4800 Oak Grove Drive</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>UNAVCO Network Engineer</contact:name>
+      <contact:telephonePrimary>303-381-7500</contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax>303-381-7451</contact:fax>
+      <contact:e-mail>ggn-ops@ls.unavco.org</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>Pasadena, CA  91109  USA </contact:notes>
+  </responsibleAgency>
+  <moreInformation>
+    <mi:primaryDataCenter></mi:primaryDataCenter>
+    <mi:secondaryDataCenter></mi:secondaryDataCenter>
+    <mi:urlForMoreInformation></mi:urlForMoreInformation>
+    <mi:hardCopyOnFile/>
+    <mi:siteMap>Y</mi:siteMap>
+    <mi:siteDiagram>Y</mi:siteDiagram>
+    <mi:horizonMask>N</mi:horizonMask>
+    <mi:monumentDescription></mi:monumentDescription>
+    <mi:sitePictures>Y</mi:sitePictures>
+    <mi:notes>(multiple lines)</mi:notes>
+    <mi:antennaGraphicsWithDimensions/>
+    <mi:insertTextGraphicFromAntenna/>
+  </moreInformation>
+</igsSiteLog>

--- a/src/test/resources/sitelog/testData/IRKJ.xml
+++ b/src/test/resources/sitelog/testData/IRKJ.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<igsSiteLog xmlns="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004" xmlns:contact="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/contact/2004" xmlns:equip="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004" xmlns:li="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004" xmlns:mi="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004  http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004/igsSiteLog.xsd"><!--Alice Springs Station Log-->
+<!--Version 0.01-->
+<!--Geoscience Australia Geodesy-->
+<!--For More Information regarding XML based Site Logs go to-->
+<!--http://sopac.ucsd.edu/projects/xml-->
+
+  <formInformation>
+    <mi:preparedBy>Valeriy A. Emelyanov</mi:preparedBy>
+    <mi:datePrepared>2007-11-01</mi:datePrepared>
+    <mi:reportType>Update</mi:reportType>
+    <mi:previousLog>irkj_20020114.log</mi:previousLog>
+    <mi:modifiedSections>3.2, 8.1.1, 8.2.1, 8.3.1, 8.4.1, 11,12,13)</mi:modifiedSections>
+  </formInformation>
+  <siteIdentification>
+    <mi:siteName>Irkutsk</mi:siteName>
+    <mi:fourCharacterID>IRKJ</mi:fourCharacterID>
+    <mi:monumentInscription>West GPS/GLONASS Geodynamical Pillar</mi:monumentInscription>
+    <mi:iersDOMESNumber>12313M002</mi:iersDOMESNumber>
+    <mi:cdpNumber>(A4)</mi:cdpNumber>
+    <mi:monumentDescription>PILLAR</mi:monumentDescription>
+    <mi:heightOfTheMonument>2.5</mi:heightOfTheMonument>
+    <mi:monumentFoundation>CONCRETE BLOCK</mi:monumentFoundation>
+    <mi:foundationDepth>2.7</mi:foundationDepth>
+    <mi:markerDescription>Metal bolt with chiseled point</mi:markerDescription>
+    <mi:dateInstalled>1995-08-23</mi:dateInstalled>
+    <mi:geologicCharacteristic>Jurassic sandstone with low fracture</mi:geologicCharacteristic>
+    <mi:bedrockType>SEDIMENTARY</mi:bedrockType>
+    <mi:bedrockCondition>WEATHERED</mi:bedrockCondition>
+    <mi:fractureSpacing>1-10 cm</mi:fractureSpacing>
+    <mi:faultZonesNearby>Baikal Rift Zone</mi:faultZonesNearby>
+    <mi:distance-Activity>Nearest deformation zone is locating</mi:distance-Activity>
+    <mi:notes>on a distance near 70 km. Distance to the nearest possible landslide spot is 1 km. Local earthquakes not observed. Transit earthquakes from Baikal Rift Zone are possible with Magnitude up to 6 and intensity 5-6 MSK64 (forecasts  up to 8 MSK64). Near 5 meters ferro-concrete pillar is installed on a bedrock. Pillar is surrounded by metal tube having diameter 1m. The space between a pillar and tube filled up by coal clinker.</mi:notes>
+  </siteIdentification>
+  <siteLocation>
+    <mi:city>Irkutsk</mi:city>
+    <mi:state></mi:state>
+    <mi:country>RUSSIA</mi:country>
+    <mi:tectonicPlate>Eurasian Plate, Siberian Platform</mi:tectonicPlate>
+    <approximatePositionITRF>
+      <mi:xCoordinateInMeters>-968328.350</mi:xCoordinateInMeters>
+      <mi:yCoordinateInMeters>3794426.541</mi:yCoordinateInMeters>
+      <mi:zCoordinateInMeters>5018167.196</mi:zCoordinateInMeters>
+      <mi:latitude-North>+521308.47</mi:latitude-North>
+      <mi:longitude-East>+1041858.24</mi:longitude-East>
+      <mi:elevation-m_ellips.>502.1</mi:elevation-m_ellips.>
+    </approximatePositionITRF>
+    <mi:notes>(multiple lines)</mi:notes>
+  </siteLocation>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>00517 Rev.3</equip:serialNumber>
+    <equip:firmwareVersion>2.2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>10</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2001-07-24T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>5-25 degrees C</equip:temperatureStabilization>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>00517 Rev.3</equip:serialNumber>
+    <equip:firmwareVersion>2.6.0 OCT,24,2007 OB</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2001-07-24T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>5-25 degrees C</equip:temperatureStabilization>
+    <equip:notes>(multiple lines)</equip:notes>
+  </gnssReceiver>
+  <gnssAntenna>
+    <equip:antennaType>JPSREGANT_SD_E  NONE</equip:antennaType>
+    <equip:serialNumber>RA0225</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.1280</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>RG 14-008012-05</equip:antennaCableType>
+    <equip:antennaCableLength>30</equip:antennaCableLength>
+    <equip:dateInstalled>2001-07-24T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes>Antenna is installed at the same position as antenna of receiver Trimble 4000SGL (IRKG station) during IGEX-98(1996-10-25/1999-11-21). We apply forced centering system for the antennas installation.</equip:notes>
+  </gnssAntenna>
+  <surveyedLocalTies>
+    <equip:tiedMarkerName>IRKT</equip:tiedMarkerName>
+    <equip:tiedMarkerUsage>GPS</equip:tiedMarkerUsage>
+    <equip:tiedMarkerCDPNumber>(A4)</equip:tiedMarkerCDPNumber>
+    <equip:tiedMarkerDOMESNumber>12313M001</equip:tiedMarkerDOMESNumber>
+    <equip:differentialComponentsGNSSMarkerToTiedMonumentsITRS>
+      <equip:dX>-3.818</equip:dX>
+      <equip:dY>1.104</equip:dY>
+      <equip:dZ>-0.496</equip:dZ>
+    </equip:differentialComponentsGNSSMarkerToTiedMonumentsITRS>
+    <equip:localSiteTiesAccuracy>5</equip:localSiteTiesAccuracy>
+    <equip:surveyMethod>GPS CAMPAIGN</equip:surveyMethod>
+    <equip:dateMeasured>1996-09-26</equip:dateMeasured>
+    <equip:notes>(multiple lines)</equip:notes>
+  </surveyedLocalTies>
+  <frequencyStandard>
+    <equip:standardType>EXTERNAL H-MASER</equip:standardType>
+    <equip:inputFrequency>5MHz</equip:inputFrequency>
+    <equip:effectiveDates>2001-07-24/CCYY-MM-DD</equip:effectiveDates>
+    <equip:notes>H-MASER CH-1-80 #216, produced by</equip:notes>
+  </frequencyStandard>
+  <collocationInformation>
+    <equip:instrumentType>GPS</equip:instrumentType>
+    <equip:status>PERMANENT</equip:status>
+    <equip:effectiveDates>1995-09-16/CCYY-MM-DD</equip:effectiveDates>
+    <equip:notes>IGS global network station IRKT working on a</equip:notes>
+  </collocationInformation>
+  <humiditySensor>
+    <equip:type>Weather Station WM-918</equip:type>
+    <equip:manufacturer>Conrad (Germany)</equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2003-02-01</equip:effectiveDates>
+    <equip:dataSamplingInterval></equip:dataSamplingInterval>
+    <equip:accuracy-percentRelativeHumidity>(% rel h)</equip:accuracy-percentRelativeHumidity>
+    <equip:aspiration>(UNASPIRATED/NATURAL/FAN/etc)</equip:aspiration>
+    <equip:notes>(multiple lines)</equip:notes>
+  </humiditySensor>
+  <pressureSensor>
+    <equip:type>Weather Station WM-918</equip:type>
+    <equip:manufacturer>Conrad (Germany)</equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2003-02-01</equip:effectiveDates>
+    <equip:dataSamplingInterval></equip:dataSamplingInterval>
+    <equip:accuracy-hPa>(hPa)</equip:accuracy-hPa>
+    <equip:notes>(multiple lines)</equip:notes>
+  </pressureSensor>
+  <temperatureSensor>
+    <equip:type>Weather Station WM-918</equip:type>
+    <equip:manufacturer>Conrad (Germany)</equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2003-02-01</equip:effectiveDates>
+    <equip:dataSamplingInterval></equip:dataSamplingInterval>
+    <equip:accuracy-degreesCelcius>(deg C)</equip:accuracy-degreesCelcius>
+    <equip:aspiration>(UNASPIRATED/NATURAL/FAN/etc)</equip:aspiration>
+    <equip:notes>(multiple lines)</equip:notes>
+  </temperatureSensor>
+  <waterVaporSensor>
+    <equip:type>Weather Station WM-918</equip:type>
+    <equip:manufacturer>Conrad (Germany)</equip:manufacturer>
+    <equip:serialNumber></equip:serialNumber>
+    <equip:heightDiffToAntenna></equip:heightDiffToAntenna>
+    <equip:calibrationDate>(CCYY-MM-DD)</equip:calibrationDate>
+    <equip:effectiveDates>2003-02-01</equip:effectiveDates>
+    <equip:distanceToAntenna></equip:distanceToAntenna>
+    <equip:notes>(multiple lines)</equip:notes>
+  </waterVaporSensor>
+  <radioInterferences>
+    <li:possibleProblemSources>CELL PHONE BASE STATION</li:possibleProblemSources>
+    <li:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</li:effectiveDates>
+    <li:observedDegredation></li:observedDegredation>
+    <li:notes>GSM900 base station is locating on a distance near 60 m from antenna of IRKJ and on azimuth 355 degrees. We no yet detected SN ratio degradation or data gaps caused by this station activity starting from January 1998 (after special testing before cellular phone base station installation).</li:notes>
+  </radioInterferences>
+  <contactAgency>
+    <contact:agency>East-Siberian branch of the</contact:agency>
+    <contact:preferredAbbreviation>East-Siberian branch of VNIIFTRI</contact:preferredAbbreviation>
+    <contact:mailingAddress>57, Borodina Str., Irkutsk, 664056,</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name>Valeriy EMELYANOV</contact:name>
+      <contact:telephonePrimary>+7-395-2-46-38-53</contact:telephonePrimary>
+      <contact:telephoneSecondary>+7-395-2-46-80-22</contact:telephoneSecondary>
+      <contact:fax>+7-395-2-46-38-48</contact:fax>
+      <contact:e-mail>eva@niiftri.irk.ru</contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>Galina MODESTOVA</contact:name>
+      <contact:telephonePrimary>+7-395-2-46-38-53</contact:telephonePrimary>
+      <contact:telephoneSecondary>+7-395-2-46-80-22</contact:telephoneSecondary>
+      <contact:fax>+7-395-2-46-38-48</contact:fax>
+      <contact:e-mail>mod@niiftri.irk.ru</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>All-Russian research insitute of physical-technical and radiotechnical measurements RUSSIA (multiple lines)</contact:notes>
+  </contactAgency>
+  <responsibleAgency>
+    <contact:agency>All-Russian research insitute</contact:agency>
+    <contact:preferredAbbreviation>VNIIFTRI</contact:preferredAbbreviation>
+    <contact:mailingAddress>Mendeleevo, Moscow Region,</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>of physical-technical and radiotechnical measurements 141570, RUSSIA (multiple lines)</contact:notes>
+  </responsibleAgency>
+  <moreInformation>
+    <mi:primaryDataCenter>http</mi:primaryDataCenter>
+    <mi:secondaryDataCenter>http</mi:secondaryDataCenter>
+    <mi:urlForMoreInformation>http</mi:urlForMoreInformation>
+    <mi:hardCopyOnFile/>
+    <mi:siteMap>Site Maps named IrkSitMap.gif and SITMAP.BMP</mi:siteMap>
+    <mi:siteDiagram>Site Diagram named SITEDIAG.BMP</mi:siteDiagram>
+    <mi:horizonMask>Horizon Mask named HORMASK.BMP</mi:horizonMask>
+    <mi:monumentDescription></mi:monumentDescription>
+    <mi:sitePictures>Site Pictures</mi:sitePictures>
+    <mi:notes>(About East-Siberian branch of VNIIFTRI, Russian language) http Engl) There are next pictures in electronic form attaching to this Log-file Monument Design named GGPILLAR.BMP Antenna installation on a top of pillar named ANTINST.BMP</mi:notes>
+    <mi:antennaGraphicsWithDimensions/>
+    <mi:insertTextGraphicFromAntenna/>
+  </moreInformation>
+</igsSiteLog>

--- a/src/test/resources/sitelog/testData/ZAMB.xml
+++ b/src/test/resources/sitelog/testData/ZAMB.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<igsSiteLog xmlns="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004" xmlns:contact="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/contact/2004" xmlns:equip="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004" xmlns:li="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004" xmlns:mi="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004  http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004/igsSiteLog.xsd"><!--Alice Springs Station Log-->
+<!--Version 0.01-->
+<!--Geoscience Australia Geodesy-->
+<!--For More Information regarding XML based Site Logs go to-->
+<!--http://sopac.ucsd.edu/projects/xml-->
+
+  <formInformation>
+    <mi:preparedBy>David Maggert</mi:preparedBy>
+    <mi:datePrepared>2013-01-31</mi:datePrepared>
+    <mi:reportType>UPDATE</mi:reportType>
+    <mi:previousLog>zamb_20120308.log</mi:previousLog>
+    <mi:modifiedSections>10.1</mi:modifiedSections>
+  </formInformation>
+  <siteIdentification>
+    <mi:siteName>Lusaka, Zambia</mi:siteName>
+    <mi:fourCharacterID>ZAMB</mi:fourCharacterID>
+    <mi:monumentInscription></mi:monumentInscription>
+    <mi:iersDOMESNumber>34601M001</mi:iersDOMESNumber>
+    <mi:cdpNumber></mi:cdpNumber>
+    <mi:monumentDescription>PILLAR</mi:monumentDescription>
+    <mi:heightOfTheMonument></mi:heightOfTheMonument>
+    <mi:monumentFoundation>ROOF</mi:monumentFoundation>
+    <mi:foundationDepth></mi:foundationDepth>
+    <mi:markerDescription>Self-centring plate locating hole</mi:markerDescription>
+    <mi:dateInstalled>2002-03-28</mi:dateInstalled>
+    <mi:geologicCharacteristic></mi:geologicCharacteristic>
+    <mi:bedrockType></mi:bedrockType>
+    <mi:bedrockCondition></mi:bedrockCondition>
+    <mi:fractureSpacing></mi:fractureSpacing>
+    <mi:faultZonesNearby></mi:faultZonesNearby>
+    <mi:distance-Activity></mi:distance-Activity>
+    <mi:notes></mi:notes>
+  </siteIdentification>
+  <siteLocation>
+    <mi:city>Lusaka</mi:city>
+    <mi:state></mi:state>
+    <mi:country>Zambia</mi:country>
+    <mi:tectonicPlate>AFRICAN</mi:tectonicPlate>
+    <approximatePositionITRF>
+      <mi:xCoordinateInMeters>5415353.0110</mi:xCoordinateInMeters>
+      <mi:yCoordinateInMeters>2917209.9140</mi:yCoordinateInMeters>
+      <mi:zCoordinateInMeters>-1685888.8650</mi:zCoordinateInMeters>
+      <mi:latitude-North>-152531.9469</mi:latitude-North>
+      <mi:longitude-East>+0281839.6445</mi:longitude-East>
+      <mi:elevation-m_ellips.>1324.9144</mi:elevation-m_ellips.>
+    </approximatePositionITRF>
+    <mi:notes>The station is located on the premises of the Zambian Surveyor General's office</mi:notes>
+  </siteLocation>
+  <gnssReceiver>
+    <equip:receiverType>ROGUE SNR-8000</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>T145</equip:serialNumber>
+    <equip:firmwareVersion>3.2.32.9</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2002-06-02T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2002-07-17T12:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization></equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ROGUE SNR-8000</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>T145</equip:serialNumber>
+    <equip:firmwareVersion>3.2.32.11</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2002-07-17T12:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2008-05-28T04:59Z</equip:dateRemoved>
+    <equip:temperatureStabilization></equip:temperatureStabilization>
+    <equip:notes>firmware upgrade</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>ASHTECH Z-XII3</equip:receiverType>
+    <equip:satelliteSystem>GPS</equip:satelliteSystem>
+    <equip:serialNumber>LP019990513</equip:serialNumber>
+    <equip:firmwareVersion>CC00</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>4</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2012-01-14T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization></equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssAntenna>
+    <equip:antennaType>AOAD/M_T        NONE</equip:antennaType>
+    <equip:serialNumber>JPL372</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0540</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>RG214</equip:antennaCableType>
+    <equip:antennaCableLength>50</equip:antennaCableLength>
+    <equip:dateInstalled>2002-03-28T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes>AA6TRI monument</equip:notes>
+  </gnssAntenna>
+  <frequencyStandard>
+    <equip:standardType>INTERNAL</equip:standardType>
+    <equip:inputFrequency></equip:inputFrequency>
+    <equip:effectiveDates>2002-06-02/CCYY-MM-DD</equip:effectiveDates>
+    <equip:notes></equip:notes>
+  </frequencyStandard>
+  <localEpisodicEvents>
+    <li:date>2011-11-18</li:date>
+    <li:event>Transitioned from .soc to .ash data types.  For</li:event>
+  </localEpisodicEvents>
+  <contactAgency>
+    <contact:agency>Jet Propulsion Laboratory</contact:agency>
+    <contact:preferredAbbreviation>JPL</contact:preferredAbbreviation>
+    <contact:mailingAddress>4800 Oak Grove Drive</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name>David A. Stowers</contact:name>
+      <contact:telephonePrimary>818-354-7055</contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax>818-393-4965</contact:fax>
+      <contact:e-mail>dstowers@jpl.nasa.gov</contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>UNAVCO Network Engineer</contact:name>
+      <contact:telephonePrimary>303-381-7500</contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax>303-381-7451</contact:fax>
+      <contact:e-mail>ggn-ops@ls.unavco.org</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>Pasadena, CA 91109 USA </contact:notes>
+  </contactAgency>
+  <responsibleAgency>
+    <contact:agency>HartRAO</contact:agency>
+    <contact:preferredAbbreviation>HRAO</contact:preferredAbbreviation>
+    <contact:mailingAddress>PO BOX 443</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>Pieter Stronkhorst</contact:name>
+      <contact:telephonePrimary>+27 12 3260742</contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax>+27 12 3260756</contact:fax>
+      <contact:e-mail>pieter@hartrao.ac.za</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>Krugersdorp 1740 South Africa </contact:notes>
+  </responsibleAgency>
+  <moreInformation>
+    <mi:primaryDataCenter></mi:primaryDataCenter>
+    <mi:secondaryDataCenter></mi:secondaryDataCenter>
+    <mi:urlForMoreInformation></mi:urlForMoreInformation>
+    <mi:hardCopyOnFile/>
+    <mi:siteMap></mi:siteMap>
+    <mi:siteDiagram>(Y)</mi:siteDiagram>
+    <mi:horizonMask>(Y)</mi:horizonMask>
+    <mi:monumentDescription></mi:monumentDescription>
+    <mi:sitePictures>(Y)</mi:sitePictures>
+    <mi:notes></mi:notes>
+    <mi:antennaGraphicsWithDimensions/>
+    <mi:insertTextGraphicFromAntenna/>
+  </moreInformation>
+</igsSiteLog>


### PR DESCRIPTION
* Why the new sopac sitelog files - The input Sopac Sitelog files were failing due to date formats
We want to leave the originals as they were.  But i need the tests
on these to run to task for other aspects.  So I made copies and
fixed the date formats