### PR TITLE
Rename equipment resource path element

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/domain/model/equipment/EquipmentRepository.java
+++ b/src/main/java/au/gov/ga/geodesy/domain/model/equipment/EquipmentRepository.java
@@ -3,7 +3,9 @@ package au.gov.ga.geodesy.domain.model.equipment;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource(path = "equipment")
 public interface EquipmentRepository extends JpaRepository<Equipment, Integer>, EquipmentRepositoryCustom {
     @Override
     List<Equipment> findAll();

--- a/src/main/java/au/gov/ga/geodesy/support/spring/GeodesyRepositoryRestMvcConfig.java
+++ b/src/main/java/au/gov/ga/geodesy/support/spring/GeodesyRepositoryRestMvcConfig.java
@@ -8,6 +8,7 @@ import org.geotools.metadata.iso.citation.TelephoneImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
@@ -38,6 +39,11 @@ import au.gov.ga.geodesy.domain.model.sitelog.SiteLog;
 
 @Configuration
 public class GeodesyRepositoryRestMvcConfig extends RepositoryRestMvcConfiguration {
+
+    @Bean
+    public RootResourceProcessor getRootResourceProcessor() {
+        return new RootResourceProcessor();
+    }
 
     @Override
     protected void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {

--- a/src/main/java/au/gov/ga/geodesy/support/spring/RootResourceProcessor.java
+++ b/src/main/java/au/gov/ga/geodesy/support/spring/RootResourceProcessor.java
@@ -1,0 +1,19 @@
+package au.gov.ga.geodesy.support.spring;
+
+import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceProcessor;
+
+/**
+ * Customise repository links resource.
+ */
+public class RootResourceProcessor implements ResourceProcessor<RepositoryLinksResource> {
+
+    @Override
+    public RepositoryLinksResource process(RepositoryLinksResource resource) {
+        Link equipment = resource.getLink("equipments").withRel("equipment");
+        resource.getLinks().remove(resource.getLink("equipments"));
+        resource.add(equipment);
+        return resource;
+    }
+}


### PR DESCRIPTION
This pull request explicitly sets the exported resource name to "equipment". By default, spring-data-rest sees the equipment entity class, and generates the "equipments" resource path.