### PR TITLE
Fix problem with incomplete EffectiveDates in Dozer

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePrimitivePropertyTypeStringConverter.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePrimitivePropertyTypeStringConverter.java
@@ -23,8 +23,10 @@ public class TimePrimitivePropertyTypeStringConverter implements CustomConverter
             return null;
         }
         if (source instanceof String) {
+            TimePrimitivePropertyType castDestination = (TimePrimitivePropertyType) destination;
+
             TimePrimitivePropertyType dest = TimePrimitivePropertyTypeUtils.addTimeInstantType(
-                    TimePrimitivePropertyTypeUtils.newOrUsingExistingTimePrimitivePropertyType(destination));
+                    TimePrimitivePropertyTypeUtils.newOrUsingExistingTimePrimitivePropertyType(castDestination));
             TimePrimitivePropertyTypeUtils.getTheTimeInstantType(dest)
                     .setTimePosition(TimePrimitivePropertyTypeUtils.buildTimePositionType((String) source));
 

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePrimitivePropertyTypeUtils.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePrimitivePropertyTypeUtils.java
@@ -25,15 +25,15 @@ public class TimePrimitivePropertyTypeUtils {
 
     /**
      * Create a new or resurrect the optionalExistingObject (TimePrimitivePropertyType).
-     * 
+     *
      * @param optionalExistingObject
      * @return new TimePrimitivePropertyType or resurrect the optionalExistingObject TimePrimitivePropertyType.
      */
-    public static TimePrimitivePropertyType newOrUsingExistingTimePrimitivePropertyType(Object optionalExistingObject) {
+    public static TimePrimitivePropertyType newOrUsingExistingTimePrimitivePropertyType(TimePrimitivePropertyType optionalExistingObject) {
         TimePrimitivePropertyType timePrimitivePropertyType = null;
 
         if (optionalExistingObject != null) {
-            timePrimitivePropertyType = (TimePrimitivePropertyType) optionalExistingObject;
+            timePrimitivePropertyType = optionalExistingObject;
         } else {
             timePrimitivePropertyType = new TimePrimitivePropertyType();
         }
@@ -41,7 +41,6 @@ public class TimePrimitivePropertyTypeUtils {
     }
 
     /**
-     * 
      * @param timePrimitivePropertyType
      * @return given timePrimitivePropertyType with a TimePeriodType payload
      */
@@ -54,7 +53,6 @@ public class TimePrimitivePropertyTypeUtils {
     }
 
     /**
-     * 
      * @param timePeriodType
      * @return JAXBElement genericised with given timePeriodType
      */
@@ -64,11 +62,10 @@ public class TimePrimitivePropertyTypeUtils {
     }
 
     /**
-     * 
      * @param timePrimitivePropertyType
      * @return given timePrimitivePropertyType with a TimePeriodType payload
      */
-    public static TimePrimitivePropertyType addTimeInstantType(TimePrimitivePropertyType timePrimitivePropertyType) {
+    static TimePrimitivePropertyType addTimeInstantType(TimePrimitivePropertyType timePrimitivePropertyType) {
         TimeInstantType timePeriodType = getGmlObjectFactory().createTimeInstantType();
         JAXBElement<TimeInstantType> jaxbTimeInstantType = buildJaxBElementTimePropertyType(timePeriodType);
 
@@ -77,17 +74,15 @@ public class TimePrimitivePropertyTypeUtils {
     }
 
     /**
-     * 
      * @param timeInstantType
      * @return JAXBElement genericised with given timeInstantType
      */
-    static JAXBElement<TimeInstantType> buildJaxBElementTimePropertyType(TimeInstantType timeInstantType) {
+    private static JAXBElement<TimeInstantType> buildJaxBElementTimePropertyType(TimeInstantType timeInstantType) {
         JAXBElement<TimeInstantType> jaxbTimeInstantType = getGmlObjectFactory().createTimeInstant(timeInstantType);
         return jaxbTimeInstantType;
     }
 
     /**
-     * 
      * @param date
      * @return TimePositionType with the given date in text with GMLDateUtils.GEODESYML_DATE_FORMAT_TIME format.
      */
@@ -106,13 +101,13 @@ public class TimePrimitivePropertyTypeUtils {
 
     /**
      * DateFormat parse the given stringDate with all possible DateFormats and add a preferred text format to the returned TimePositionType
-     * 
-     * @See au.gov.ga.geodesy.support.utils.GMLDateUtils
+     *
      * @param stringDate
      * @return TimePositionType with the given date in text with GMLDateUtils DateFormat that is the output format for the DateFormat that
-     *         matches
+     * matches
+     * @See au.gov.ga.geodesy.support.utils.GMLDateUtils
      */
-    static TimePositionType buildTimePositionType(String stringDate) {
+    public static TimePositionType buildTimePositionType(String stringDate) {
         List<String> dateStrings = new ArrayList<>();
         if (stringDate == null) {
             // Date wasn't included in data - leave List empty
@@ -128,9 +123,9 @@ public class TimePrimitivePropertyTypeUtils {
     /**
      * TimePrimitivePropertyType can hold various payloads. It will be a ClassCastException if the wrong type is asked for so be aware of
      * which type is used where.
-     * 
+     * <p>
      * Also @see TimePeriodPropertyTypeUtils#getTheTimeInstantType(TimePrimitivePropertyType)
-     * 
+     *
      * @param timePrimitivePropertyType
      * @return TimePeriodType payload of the given timePrimitivePropertyType
      */
@@ -143,9 +138,9 @@ public class TimePrimitivePropertyTypeUtils {
     /**
      * TimePrimitivePropertyType can hold various payloads. It will be a ClassCastException if the wrong type is asked for so be aware of
      * which type is used where.
-     * 
+     * <p>
      * Also @see {@link #getTheTimePeriodType(TimePrimitivePropertyType)}
-     * 
+     *
      * @param timePrimitivePropertyType
      * @return TimeInstantType payload of the given timePrimitivePropertyType
      */
@@ -154,13 +149,65 @@ public class TimePrimitivePropertyTypeUtils {
                 .getValue();
         return timeInstantType;
     }
-    
-    public static TimePrimitivePropertyType buildTimePrimitivePropertyType(Instant timePositionTypeDate) {
+
+    private static TimePrimitivePropertyType buildTimePrimitivePropertyType_TimeInstantType(Instant timePositionTypeDate) {
         TimePrimitivePropertyType timePrimitivePropertyType = TimePrimitivePropertyTypeUtils
                 .addTimeInstantType(TimePrimitivePropertyTypeUtils.newOrUsingExistingTimePrimitivePropertyType(null));
         TimePrimitivePropertyTypeUtils.getTheTimeInstantType(timePrimitivePropertyType)
                 .setTimePosition(TimePrimitivePropertyTypeUtils.buildTimePositionType(timePositionTypeDate));
 
         return timePrimitivePropertyType;
+    }
+
+    /**
+     * Build a TimePrimitivePropertyType containint a TimePeriodType.  If either of Being or End are null then the
+     * beginPosition or endPosition of the TimePeriodDtype will be null.
+     *
+     * @param begin
+     * @param end
+     * @return
+     */
+    private static TimePrimitivePropertyType buildTimePrimitivePropertyType_TimePeriodType(Instant begin, Instant end) {
+        TimePrimitivePropertyType timePrimitivePropertyType = TimePrimitivePropertyTypeUtils
+                .addTimePeriodType(TimePrimitivePropertyTypeUtils.newOrUsingExistingTimePrimitivePropertyType(null));
+        TimePeriodType tpt = TimePrimitivePropertyTypeUtils.getTheTimePeriodType(timePrimitivePropertyType);
+        if (begin != null) {
+            tpt.setBeginPosition(TimePrimitivePropertyTypeUtils.buildTimePositionType(begin));
+        }
+        if (end != null) {
+            tpt.setEndPosition(TimePrimitivePropertyTypeUtils.buildTimePositionType(end));
+        }
+        return timePrimitivePropertyType;
+    }
+
+    /**
+     * @return new TimePrimitivePropertyType without any Time type payload
+     */
+    public static TimePrimitivePropertyType buildTimePrimitivePropertyType() {
+        return TimePrimitivePropertyTypeUtils.newOrUsingExistingTimePrimitivePropertyType(null);
+    }
+
+    public static TimePrimitivePropertyType buildTimePrimitivePropertyType(Instant instant) {
+        if (instant == null) {
+            return buildTimePrimitivePropertyType();
+        }
+        return buildTimePrimitivePropertyType_TimeInstantType(instant);
+    }
+
+    /**
+     * Build a TimePrimitivePropertyType containing a TimePeriodType.  If either of Being or End are null then the
+     * beginPosition or endPosition of the TimePeriodDtype will be null.  If both are null the TimePrimitivePropertyType
+     * will contain now Time payload.
+     *
+     * @param begin
+     * @param end
+     * @return new TimePrimitivePropertyType with optional TimePeriodType or TimeInstantType payload if those
+     * arguments are given.
+     */
+    public static TimePrimitivePropertyType buildTimePrimitivePropertyType(Instant begin, Instant end) {
+        if (begin == null && end == null) {
+            return buildTimePrimitivePropertyType();
+        }
+        return buildTimePrimitivePropertyType_TimePeriodType(begin, end);
     }
 }

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePrimitivePropertyTypeUtilsTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePrimitivePropertyTypeUtilsTest.java
@@ -1,0 +1,93 @@
+package au.gov.ga.geodesy.support.mapper.dozer.converter;
+
+import net.opengis.gml.v_3_2_1.TimeInstantType;
+import net.opengis.gml.v_3_2_1.TimePeriodType;
+import net.opengis.gml.v_3_2_1.TimePrimitivePropertyType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by brookes on 14/06/16.
+ */
+public class TimePrimitivePropertyTypeUtilsTest {
+    @Test
+    public void NoInstantNorPeriod() throws Exception {
+        // No arg
+        TimePrimitivePropertyType timePrimitivePropertyType = TimePrimitivePropertyTypeUtils.buildTimePrimitivePropertyType();  // should be no child time (neither instant nor period)
+        Assert.assertNull(timePrimitivePropertyType.getAbstractTimePrimitive());
+    }
+
+    @Test
+    public void TwoNullArgs_NoInstantNorPeriod() throws Exception {
+        // No arg
+        TimePrimitivePropertyType timePrimitivePropertyType = TimePrimitivePropertyTypeUtils.buildTimePrimitivePropertyType(null, null);  // should be no child time (neither instant nor period)
+        Assert.assertNull(timePrimitivePropertyType.getAbstractTimePrimitive());
+    }
+
+    @Test
+    public void OneArg_Instant() throws Exception {
+        // One arg - should construct an Instant
+        Instant now = Instant.now();
+
+        TimePrimitivePropertyType timePrimitivePropertyType = TimePrimitivePropertyTypeUtils.buildTimePrimitivePropertyType(now);
+        TimeInstantType tit = TimePrimitivePropertyTypeUtils.getTheTimeInstantType(timePrimitivePropertyType);
+        Assert.assertNotNull(tit);
+        Assert.assertNotNull(tit.getTimePosition());
+        Assert.assertNotNull(tit.getTimePosition().getValue());
+        Assert.assertEquals(1, tit.getTimePosition().getValue().size());
+    }
+
+    @Test
+    public void TwoArgs_Period() throws Exception {
+        // Two args - should construct a Period with begin and end
+        Instant end = Instant.now();
+        Instant begin = end.minus(1, ChronoUnit.DAYS);
+
+        TimePrimitivePropertyType timePrimitivePropertyType = TimePrimitivePropertyTypeUtils.buildTimePrimitivePropertyType(begin, end);
+        TimePeriodType tpt = TimePrimitivePropertyTypeUtils.getTheTimePeriodType(timePrimitivePropertyType);
+        Assert.assertNotNull(tpt);
+        // Now test for begin and end
+        Assert.assertNotNull(tpt.getBeginPosition());
+        Assert.assertNotNull(tpt.getBeginPosition().getValue());
+        Assert.assertEquals(1, tpt.getBeginPosition().getValue().size());
+        Assert.assertNotNull(tpt.getEndPosition());
+        Assert.assertNotNull(tpt.getEndPosition().getValue());
+        Assert.assertEquals(1, tpt.getEndPosition().getValue().size());
+    }
+
+    @Test
+    public void OneArgBegin_Period() throws Exception {
+        // Two args - first only, null for second - should construct a Period with null end
+        Instant begin = Instant.now();
+
+        TimePrimitivePropertyType timePrimitivePropertyType = TimePrimitivePropertyTypeUtils.buildTimePrimitivePropertyType(begin, null);
+        TimePeriodType tpt = TimePrimitivePropertyTypeUtils.getTheTimePeriodType(timePrimitivePropertyType);
+        Assert.assertNotNull(tpt);
+        // Now test for begin and end
+        Assert.assertNotNull(tpt.getBeginPosition());
+        Assert.assertNotNull(tpt.getBeginPosition().getValue());
+        Assert.assertEquals(1, tpt.getBeginPosition().getValue().size());
+        Assert.assertNull(tpt.getEndPosition());
+    }
+
+    @Test
+    public void oneArgEnd_Period() throws Exception {
+        // Two args - second only, null for first - should construct a Period with null begin
+        Instant end = Instant.now();
+
+        TimePrimitivePropertyType timePrimitivePropertyType = TimePrimitivePropertyTypeUtils.buildTimePrimitivePropertyType(null, end);
+        TimePeriodType tpt = TimePrimitivePropertyTypeUtils.getTheTimePeriodType(timePrimitivePropertyType);
+        Assert.assertNotNull(tpt);
+        // Now test for begin and end
+        Assert.assertNull(tpt.getBeginPosition());
+        Assert.assertNotNull(tpt.getEndPosition());
+        Assert.assertNotNull(tpt.getEndPosition().getValue());
+        Assert.assertEquals(1, tpt.getEndPosition().getValue().size());
+    }
+}


### PR DESCRIPTION
* Fixed the case where the EffectiveDate from the data is null.
Previously 1/1/1970 TimeInstantType being returned.
Now returns TimePeriodType with empty lists for begin and end.
* Also fixed minor date tests