### PR TITLE
Fix EffectiveDate in RadioInterference dozer mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,6 @@
                     <excludes>
                         <exclude>au/gov/ga/geodesy/ngcp/**/*</exclude>
                         <!-- exclude the following 2 tests, they broke due to sinex files being exluded - see commit https://github.com/GeoscienceAustralia/geodesy-domain-model/commit/e05fd32883405b9f1901c038424012a780019eeb  -->
-                        <exclude>au/gov/ga/geodesy/support/mapper/dozer/**/*</exclude>
                         <exclude>au/gov/ga/geodesy/port/adapter/rest/UploadSolutionRestTest.java</exclude>
                         <exclude>au/gov/ga/geodesy/test/integration/standalone/*.java</exclude>
                     </excludes>

--- a/src/main/java/au/gov/ga/geodesy/port/adapter/geodesyml/SopacFileTranslator.java
+++ b/src/main/java/au/gov/ga/geodesy/port/adapter/geodesyml/SopacFileTranslator.java
@@ -1,0 +1,100 @@
+package au.gov.ga.geodesy.port.adapter.geodesyml;
+
+import au.gov.ga.geodesy.exception.GeodesyRuntimeException;
+import au.gov.ga.geodesy.igssitelog.domain.model.IgsSiteLog;
+import au.gov.ga.geodesy.igssitelog.interfaces.xml.IgsSiteLogXmlMarshaller;
+import au.gov.ga.geodesy.support.mapper.dozer.GeodesyMLSiteLogDozerTranslator;
+import au.gov.xml.icsm.geodesyml.v_0_3.GeodesyMLType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.xml.bind.JAXBElement;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Translate Sopac file into GeodesyML
+ */
+@Service
+public class SopacFileTranslator {
+
+    @Autowired
+    private IgsSiteLogXmlMarshaller marshaller;
+
+    @Autowired
+    private GeodesyMLSiteLogDozerTranslator geodesyMLSiteLogTranslator;
+
+    @Autowired
+    private GeodesyMLMarshaller geodesyMLMarshaller;
+
+    private final Path outputTemporaryDir;
+
+    public SopacFileTranslator() throws IOException {
+        outputTemporaryDir = Files.createTempDirectory("geodesyMLOutput");
+    }
+
+    /**
+     * Translate given single SOPAC Sitelog file to GeodesyML file in a temporary directory
+     *
+     * @param inputTestFile input file to translate
+     * @return output translated file full path - Output file will be be in temp directory with same name as input file
+     * @throws IOException
+     * @throws au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException
+     * @throws MarshallingException
+     */
+    public String translateFileToTempDirectory(File inputTestFile)
+            throws IOException, au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, MarshallingException {
+        return translateFile(inputTestFile, outputTemporaryDir);
+    }
+
+    /**
+     * Translate given single SOPAC Sitelog file to GeodesyML file in given outputDirectory directory
+     *
+     * @param inputTestFile input file to translate
+     * @return output translated file full path - Output file will be be in given directory with same name as input file
+     * @throws IOException
+     * @throws au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException
+     * @throws MarshallingException
+     */
+    public String translateFile(File inputTestFile, Path outputDirectory)
+            throws IOException, au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, MarshallingException {
+        Logger logger = LoggerFactory.getLogger(SopacFileTranslator.class);
+
+        Path outputFile = Paths.get(outputDirectory.toString(), getFileName(inputTestFile.getName()));
+        Reader inputFileReader = new FileReader(inputTestFile);
+
+        logger.info("Translate File - Sopac to GeodesyML");
+        logger.info("  Input: " + inputTestFile.getName());
+        logger.info("  Output: " + outputFile.toString());
+
+        IgsSiteLog siteLog = marshaller.unmarshal(inputFileReader);
+
+        JAXBElement<GeodesyMLType> geodesyMLJAXB = geodesyMLSiteLogTranslator.dozerTranslate(siteLog);
+
+        GeodesyMLType geodesyML = geodesyMLJAXB.getValue();
+
+        if (geodesyML == null) {
+            throw new GeodesyRuntimeException("geodesyML == null");
+        }
+
+        FileWriter writer = new FileWriter(outputFile.toFile());
+        geodesyMLMarshaller.marshal(geodesyMLJAXB, writer);
+
+        return outputFile.toString();
+    }
+
+    /**
+     * Given a fileName in a path, return just the filename.
+     *
+     * @param fileName
+     * @return just file name after final '/' or the fileName if no '/'
+     */
+    private static String getFileName(String fileName) {
+        String[] parts = fileName.split("/");
+        return parts.length - 1 >= 0 ? (parts[parts.length - 1]) : fileName;
+    }
+}

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePrimitivePropertyTypeEffectiveDatesConverter.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/converter/TimePrimitivePropertyTypeEffectiveDatesConverter.java
@@ -84,15 +84,13 @@ public class TimePrimitivePropertyTypeEffectiveDatesConverter implements CustomC
         if (!(source instanceof EffectiveDates)) {
             return null;
         }
-        // new TimePrimitivePropertyType or use existing one if exists
-        TimePrimitivePropertyType dest = TimePrimitivePropertyTypeUtils.addTimePeriodType(
-                TimePrimitivePropertyTypeUtils.newOrUsingExistingTimePrimitivePropertyType(destination));
+        // I am ignoring the destination being an object that shouuld be used since I've never encountered such a circumstance
 
-        // Populate begin and end from the EffectiveDates
-        TimePrimitivePropertyTypeUtils.getTheTimePeriodType(dest).setBeginPosition(
-                TimePrimitivePropertyTypeUtils.buildTimePositionType(((EffectiveDates) source).getFrom()));
-        TimePrimitivePropertyTypeUtils.getTheTimePeriodType(dest)
-                .setEndPosition(TimePrimitivePropertyTypeUtils.buildTimePositionType(((EffectiveDates) source).getTo()));
+        EffectiveDates sourceCast = (EffectiveDates)  source;
+        TimePrimitivePropertyType dest = TimePrimitivePropertyTypeUtils.buildTimePrimitivePropertyType(sourceCast.getFrom(), sourceCast.getTo());
+        if (dest.getAbstractTimePrimitive() == null) {
+            return null;
+        }
         return dest;
     }
 

--- a/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/populator/RadioInterferencesTypePopulator.java
+++ b/src/main/java/au/gov/ga/geodesy/support/mapper/dozer/populator/RadioInterferencesTypePopulator.java
@@ -10,14 +10,13 @@ public class RadioInterferencesTypePopulator extends GeodesyMLElementPopulator<R
 
     /**
      * Consider all required elements for this type and add any missing ones with default values.
-     * 
+     *
      * @param radioInterferencesType
      */
     @Override
     public void checkAllRequiredElementsPopulated(RadioInterferencesType radioInterferencesType) {
         checkElementPopulated(radioInterferencesType, "observedDegradations", GMLMiscTools.getEmptyString());
         checkElementPopulated(radioInterferencesType, "possibleProblemSources", GMLMiscTools.getEmptyString());
-        checkElementPopulated(radioInterferencesType, "validTime",
-                TimePrimitivePropertyTypeUtils.buildTimePrimitivePropertyType(Instant.EPOCH));
+        // No longer checking validTime as if null I want it to remain that way (because input was null)
     }
 }

--- a/src/test/java/au/gov/ga/geodesy/port/adapter/rest/UploadZIMJGeodesyMLSiteLogRestTest.java
+++ b/src/test/java/au/gov/ga/geodesy/port/adapter/rest/UploadZIMJGeodesyMLSiteLogRestTest.java
@@ -1,0 +1,90 @@
+package au.gov.ga.geodesy.port.adapter.rest;
+
+import au.gov.ga.geodesy.exception.GeodesyRuntimeException;
+import au.gov.ga.geodesy.igssitelog.domain.model.IgsSiteLog;
+import au.gov.ga.geodesy.igssitelog.interfaces.xml.IgsSiteLogXmlMarshaller;
+import au.gov.ga.geodesy.port.adapter.geodesyml.GeodesyMLMarshaller;
+import au.gov.ga.geodesy.port.adapter.geodesyml.MarshallingException;
+import au.gov.ga.geodesy.port.adapter.geodesyml.SopacFileTranslator;
+import au.gov.ga.geodesy.support.TestResources;
+import au.gov.ga.geodesy.support.mapper.dozer.GeodesyMLSiteLogDozerTranslator;
+import au.gov.xml.icsm.geodesyml.v_0_3.GeodesyMLType;
+import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.MediaType;
+import org.testng.annotations.Test;
+
+import javax.xml.bind.JAXBElement;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static au.gov.ga.geodesy.port.adapter.rest.ResultHandlers.print;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * ZIMJ was randomly chosen as a test case for the RadioInterference's EffectiveDates fixes I recently made.  There are various SOPAC test inputs.
+ * This sopac -> geodesyml (dozer mapping) converts these and then uploads them.
+ */
+public class UploadZIMJGeodesyMLSiteLogRestTest extends RestTest {
+
+    @Autowired
+    private SopacFileTranslator sopacFileTranslator;
+
+    /**
+     * Translate Sopace to GeodesyML file in resources sopac testData directory
+     *
+     * @param file in resources sopac testData directory
+     * @return the output (translated) file path
+     * @throws au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException
+     * @throws MarshallingException
+     * @throws IOException
+     */
+    private String translateFile(String file) throws au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, MarshallingException, IOException {
+        return sopacFileTranslator.translateFileToTempDirectory(TestResources.sopacSiteLogTestData(file));
+    }
+
+    private void uploadCheckFile(String file) throws Exception {
+        String content = IOUtils.toString(new FileReader(file));
+        mvc.perform(post("/siteLog/upload").contentType(MediaType.APPLICATION_XML).content(content))
+                .andExpect(status().isCreated());
+    }
+
+    private void checkUpload(String fourCharacterID) throws Exception {
+        mvc.perform(get("/corsSites/search/findByFourCharacterId?id=" + fourCharacterID))
+                .andExpect(status().isOk())
+                .andDo(print);
+    }
+
+    @Test
+    public void checkZIMJ_withEffectiveDates() throws Exception {
+        String outfile = translateFile("ZIMJ-radioInterference-withEffectiveDates");
+        uploadCheckFile(outfile);
+        checkUpload("ZIMJ");
+    }
+
+    @Test
+    public void checkZIMJ_noEffectiveDates() throws Exception {
+        String outfile = translateFile("ZIMJ-radioInterference-noEffectiveDates");
+        uploadCheckFile(outfile);
+        checkUpload("ZIMJ");
+    }
+
+    @Test
+    public void checkZIMJ_withEffectiveDatesNoToForm1() throws Exception {
+        String outfile = translateFile("ZIMJ-radioInterference-withEffectiveDatesNoToForm1");
+        uploadCheckFile(outfile);
+        checkUpload("ZIMJ");
+    }
+
+    @Test
+    public void checkZIMJ_withEffectiveDatesNoToForm2() throws Exception {
+        String outfile = translateFile("ZIMJ-radioInterference-withEffectiveDatesNoToForm2");
+        uploadCheckFile(outfile);
+        checkUpload("ZIMJ");
+    }
+}

--- a/src/test/java/au/gov/ga/geodesy/support/TestResources.java
+++ b/src/test/java/au/gov/ga/geodesy/support/TestResources.java
@@ -1,14 +1,14 @@
 package au.gov.ga.geodesy.support;
 
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 /**
  * A collection of static methods to access regression test data.
@@ -37,6 +37,10 @@ public class TestResources {
         return "/sitelog/geodesyml/";
     }
 
+    private static String geodesyMLSiteLogsTestDataDirectory() {
+        return "/sitelog/testData/";
+    }
+
     /**
      * GeodesyML site logs directory relative to classpath root.  Files that have been converted from production Sopac Sitelogs
      */
@@ -59,6 +63,13 @@ public class TestResources {
     }
 
     /**
+     * Given a site id, return a SOPAC site log test file.
+     */
+    public static File sopacSiteLogTestData(String siteId) throws IOException {
+        return resourceAsFile(geodesyMLSiteLogTestDataResourceName(siteId));
+    }
+
+    /**
      * Given a site id, return a SOPAC site log test file reader.
      */
     public static Reader sopacSiteLogReader(String siteId) throws IOException {
@@ -73,17 +84,17 @@ public class TestResources {
     }
 
     /**
-     * Given a site id, return a sopac converted to GeodesyML site log test file reader.  File from resources:/sitelogtoGeodesyML
-     */
-    public static Reader geodesyMLSopacConvertedSiteLogReader(String siteId) throws IOException {
-        return new FileReader(resourceAsFile(geodesyMLSopacConvertedSiteLogResourceName(siteId)));
-    }
-
-    /**
      * Given a site id, return a sopac converted to GeodesyML site log test file reader.  File from resources:/sitelog/geodesyMLTestData
      */
     public static Reader geodesyMLTestDataSiteLogReader(String siteId) throws IOException {
         return new FileReader(resourceAsFile(geodesyMLTestDataSiteLogResourceName(siteId)));
+    }
+
+    /**
+     * Given a site id, return a GeodesyML site log test file reader.
+     */
+    public static Reader geodesyMLSiteLogTestDataReader(String siteId) throws IOException {
+        return new FileReader(resourceAsFile(geodesyMLSiteLogTestDataResourceName(siteId)));
     }
 
     /**
@@ -119,6 +130,10 @@ public class TestResources {
         return geodesyMLSiteLogsDirectory() + id + ".xml";
     }
 
+    private static String geodesyMLSiteLogTestDataResourceName(String id) {
+        return geodesyMLSiteLogsTestDataDirectory() + id + ".xml";
+    }
+
     /**
      * GeodesyML site log resource name relative to classpath root.
      */
@@ -137,7 +152,7 @@ public class TestResources {
     /**
      * Find a resource relative to classpath root.
      */
-    private static File resourceAsFile(String resourceName) throws IOException {
+    public static File resourceAsFile(String resourceName) throws IOException {
         Resource resource = new PathMatchingResourcePatternResolver().getResource("classpath:" + resourceName);
         if (resource == null) {
             throw new IllegalArgumentException("Resource " + resourceName + " must exist.");

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/decorator/IdDecoratorTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/decorator/IdDecoratorTest.java
@@ -2,7 +2,6 @@ package au.gov.ga.geodesy.support.mapper.decorator;
 
 import java.lang.reflect.Method;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.util.List;
 
 import org.hamcrest.MatcherAssert;
@@ -17,7 +16,6 @@ import au.gov.xml.icsm.geodesyml.v_0_3.GeodesyMLType;
 import au.gov.xml.icsm.geodesyml.v_0_3.HumiditySensorPropertyType;
 import au.gov.xml.icsm.geodesyml.v_0_3.HumiditySensorType;
 import au.gov.xml.icsm.geodesyml.v_0_3.ObjectFactory;
-import net.opengis.gml.v_3_2_1.TimePrimitivePropertyType;
 
 public class IdDecoratorTest {
     private ObjectFactory geoFactory = new ObjectFactory();

--- a/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/TranslateTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/mapper/dozer/TranslateTest.java
@@ -665,4 +665,87 @@ public class TranslateTest { // extends AbstractTestNGSpringContextTests {
 
         Assert.assertNotNull(geodesyML);
     }
+
+    @Test
+    public void testZIMJ_RadioInterference_WithEffectiveDates() throws MarshallingException, IOException,
+            au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, ParseException {
+        GeodesyMLType geodesyML = testTranslate(TESTDATADIR, "ZIMJ-radioInterference-withEffectiveDates");
+
+        Assert.assertNotNull(geodesyML);
+        SiteLogType siteLogType = getSiteLog(geodesyML);
+
+        List<RadioInterferencesPropertyType> radioInterferences = siteLogType.getRadioInterferencesSet();
+        Assert.assertNotNull(radioInterferences);
+        Assert.assertEquals(radioInterferences.size(), 1);
+        RadioInterferencesPropertyType radioInterference = radioInterferences.get(0);
+
+        AbstractTimePrimitiveType validTime = radioInterference.getRadioInterferences().getValidTime().getAbstractTimePrimitive().getValue();
+        Assert.assertTrue(validTime instanceof TimePeriodType, "Should be a TimePeriodType");
+
+        TimePositionType begin = ((TimePeriodType) validTime).getBeginPosition();
+        TimePositionType end = ((TimePeriodType) validTime).getEndPosition();
+
+        Assert.assertNotNull(begin);
+        Assert.assertEquals(1, begin.getValue().size());
+        Assert.assertNotNull(end);
+        Assert.assertEquals(1, end.getValue().size());
+    }
+
+    @Test
+    public void testZIMJ_RadioInterference_WithNoEffectiveDates() throws MarshallingException, IOException,
+            au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, ParseException {
+        GeodesyMLType geodesyML = testTranslate(TESTDATADIR, "ZIMJ-radioInterference-noEffectiveDates");
+
+        Assert.assertNotNull(geodesyML);
+        SiteLogType siteLogType = getSiteLog(geodesyML);
+
+        List<RadioInterferencesPropertyType> radioInterferences = siteLogType.getRadioInterferencesSet();
+        Assert.assertNotNull(radioInterferences);
+        Assert.assertEquals(radioInterferences.size(), 1);
+        RadioInterferencesType radioInterference = radioInterferences.get(0).getRadioInterferences();
+
+        TimePrimitivePropertyType timePrimitive = radioInterference.getValidTime();
+
+        Assert.assertNull(timePrimitive);
+    }
+
+
+    // EffectiveDates without a To Date should return a TimePeriodType with a getEndPosition() that ISN'T NULL but is an empty list
+    public void testZIMJ_RadioInterference_WithEffectiveDates_NoToForms(GeodesyMLType geodesyML) {
+        Assert.assertNotNull(geodesyML);
+        SiteLogType siteLogType = getSiteLog(geodesyML);
+
+        List<RadioInterferencesPropertyType> radioInterferences = siteLogType.getRadioInterferencesSet();
+        Assert.assertNotNull(radioInterferences);
+        Assert.assertEquals(radioInterferences.size(), 1);
+        RadioInterferencesPropertyType radioInterference = radioInterferences.get(0);
+
+        AbstractTimePrimitiveType validTime = radioInterference.getRadioInterferences().getValidTime().getAbstractTimePrimitive().getValue();
+        Assert.assertTrue(validTime instanceof TimePeriodType, "Should be a TimePeriodType");
+
+        TimePositionType begin = ((TimePeriodType) validTime).getBeginPosition();
+        TimePositionType end = ((TimePeriodType) validTime).getEndPosition();
+
+        Assert.assertNotNull(begin);
+        Assert.assertEquals(1, begin.getValue().size());
+        Assert.assertNull(end);
+
+        Assert.assertEquals(
+                GMLDateUtils.stringToDateToStringMultiParsers(begin.getValue().get(0)),
+                "2012-01-15T00:00:00.000Z");
+    }
+
+    @Test
+    public void testZIMJ_RadioInterference_WithEffectiveDates_NoToForm1() throws ParseException, au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, MarshallingException, IOException {
+        GeodesyMLType geodesyML = testTranslate(TESTDATADIR, "ZIMJ-radioInterference-withEffectiveDatesNoToForm1");
+        testZIMJ_RadioInterference_WithEffectiveDates_NoToForms(geodesyML);
+    }
+
+    @Test
+    public void testZIMJ_RadioInterference_WithEffectiveDates_NoToForm2() throws ParseException, au.gov.ga.geodesy.igssitelog.interfaces.xml.MarshallingException, MarshallingException, IOException {
+        GeodesyMLType geodesyML = testTranslate(TESTDATADIR, "ZIMJ-radioInterference-withEffectiveDatesNoToForm2");
+        testZIMJ_RadioInterference_WithEffectiveDates_NoToForms(geodesyML);
+    }
+
+
 }

--- a/src/test/resources/sitelog/testData/ZIMJ-radioInterference-noEffectiveDates.xml
+++ b/src/test/resources/sitelog/testData/ZIMJ-radioInterference-noEffectiveDates.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<igsSiteLog xmlns="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004" xmlns:contact="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/contact/2004" xmlns:equip="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004" xmlns:li="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004" xmlns:mi="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004  http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004/igsSiteLog.xsd"><!--Alice Springs Station Log-->
+<!--Version 0.01-->
+<!--Geoscience Australia Geodesy-->
+<!--For More Information regarding XML based Site Logs go to-->
+<!--http://sopac.ucsd.edu/projects/xml-->
+
+  <formInformation>
+    <mi:preparedBy>Christian Baumann (AIUB)</mi:preparedBy>
+    <mi:datePrepared>2013-05-21</mi:datePrepared>
+    <mi:reportType>UPDATE</mi:reportType>
+    <mi:previousLog>zimj_20121007.log</mi:previousLog>
+    <mi:modifiedSections>3.11, 3.12, 4.2, 5., 7.3, 7.4, 8., 11., 13.</mi:modifiedSections>
+  </formInformation>
+  <siteIdentification>
+    <mi:siteName>Zimmerwald GPS87E</mi:siteName>
+    <mi:fourCharacterID>ZIMJ</mi:fourCharacterID>
+    <mi:monumentInscription>GPS87E</mi:monumentInscription>
+    <mi:iersDOMESNumber>14001M006</mi:iersDOMESNumber>
+    <mi:cdpNumber></mi:cdpNumber>
+    <mi:monumentDescription>STEEL MAST</mi:monumentDescription>
+    <mi:heightOfTheMonument></mi:heightOfTheMonument>
+    <mi:monumentFoundation>ROOF of the observatory</mi:monumentFoundation>
+    <mi:foundationDepth></mi:foundationDepth>
+    <mi:markerDescription>Eccentric mount on steel mast (GPS87)</mi:markerDescription>
+    <mi:dateInstalled>1995-01-01</mi:dateInstalled>
+    <mi:geologicCharacteristic>CONGLOMERATE</mi:geologicCharacteristic>
+    <mi:bedrockType>SEDIMENTARY</mi:bedrockType>
+    <mi:bedrockCondition>JOINTED</mi:bedrockCondition>
+    <mi:fractureSpacing></mi:fractureSpacing>
+    <mi:faultZonesNearby></mi:faultZonesNearby>
+    <mi:distance-Activity></mi:distance-Activity>
+    <mi:notes>Morraine Exact date in 1995 not known</mi:notes>
+  </siteIdentification>
+  <siteLocation>
+    <mi:city>Zimmerwald</mi:city>
+    <mi:state>Bern</mi:state>
+    <mi:country>Switzerland</mi:country>
+    <mi:tectonicPlate>Eurasian Plate</mi:tectonicPlate>
+    <approximatePositionITRF>
+      <mi:xCoordinateInMeters>4331294.043</mi:xCoordinateInMeters>
+      <mi:yCoordinateInMeters>567541.982</mi:yCoordinateInMeters>
+      <mi:zCoordinateInMeters>4633135.625</mi:zCoordinateInMeters>
+      <mi:latitude-North>+465237.70</mi:latitude-North>
+      <mi:longitude-East>+0072754.36</mi:longitude-East>
+      <mi:elevation-m_ellips.>954.3</mi:elevation-m_ellips.>
+    </approximatePositionITRF>
+    <mi:notes>ITRF2000, epoch 1997.0</mi:notes>
+  </siteLocation>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.4 Jan 22,1999</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-02-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-04-16</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.5 Mar,18,1999 pl3</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-04-17T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-05-05</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.6 Apr,26,1999 pl1</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-05-06T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-07-05</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.8 Jun,17,1999 pl2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-07-06T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-08-16</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.9 Aug,11,1999 pl2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-08-17T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2000-08-08</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.1 Jun,16,2000</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2000-08-09T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2003-10-08</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.3 Aug,01,2003 p2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2003-10-08T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.3 APR,28,2004 p4</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2003-10-08T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2007-10-30T12:59Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.6.0 Oct,24,2007 ob</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2007-10-30T13:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.6.1 Jan,10,2008</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2008-01-16T10:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2010-10-22T13:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JAVAD TRE_G3TH DELTA</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO+GAL+SBAS</equip:satelliteSystem>
+    <equip:serialNumber>00634</equip:serialNumber>
+    <equip:firmwareVersion>3.2.6 Feb,24,2011</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2011-06-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2013-04-30T16:30Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes>Exact date in 2011 not known</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JAVAD TRE_G3TH DELTA</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO+GAL+SBAS</equip:satelliteSystem>
+    <equip:serialNumber>00634</equip:serialNumber>
+    <equip:firmwareVersion>3.4.9 Apr,18,2013</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2013-04-30T16:32Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssAntenna>
+    <equip:antennaType>JPSREGANT_SD_E1 NONE</equip:antennaType>
+    <equip:serialNumber>RA0059</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0770</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength>Approx. 10</equip:antennaCableLength>
+    <equip:dateInstalled>1999-02-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes> Antenna type listed in this section retro- actively changed from JPSREGANT_SD_E to JPSREGANT_SD_E1 starting with log file zimj_20121007.log. See IGSMAIL-6662 and IGSMAIL-6663 for details.</equip:notes>
+  </gnssAntenna>
+  <gnssAntenna>
+    <equip:antennaType>JAVRINGANT_DM   NONE</equip:antennaType>
+    <equip:serialNumber>00427</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0770</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength></equip:antennaCableLength>
+    <equip:dateInstalled>2011-06-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes>Individual absolute antenna calibration values are available</equip:notes>
+  </gnssAntenna>
+  <frequencyStandard>
+    <equip:standardType>INTERNAL</equip:standardType>
+    <equip:inputFrequency></equip:inputFrequency>
+    <equip:effectiveDates></equip:effectiveDates>
+    <equip:notes></equip:notes>
+  </frequencyStandard>
+  <collocationInformation>
+    <equip:instrumentType>SLR </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1976-01-01 </equip:effectiveDates>
+    <equip:notes>New telescope since 1996  Exact date in 1976 not known</equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>Earth tide gravimeter </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1995-01-01 </equip:effectiveDates>
+    <equip:notes>Swiss Federal Institute of Technology  Geodesy and Geodynamics Lab (GGL)  ETH-Hoenggerberg  CH-8093 Zurich  Exact date in 1995 not known</equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>GPS </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1993-05-01 </equip:effectiveDates>
+    <equip:notes>Official IGS site ZIMM 14001M004  See IGS site log file zimm*.log </equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>GPS/GLONASS </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>2007-11-08</equip:effectiveDates>
+    <equip:notes>Official IGLOS site   ZIM2 14001M008  See IGS site log file zim2*.log </equip:notes>
+  </collocationInformation>
+  <radioInterferences>
+    <li:possibleProblemSources>TV</li:possibleProblemSources>
+    <li:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</li:effectiveDates>
+    <li:observedDegredation></li:observedDegredation>
+    <li:notes>(multiple lines)</li:notes>
+  </radioInterferences>
+  <multipathSources>
+    <li:possibleProblemSources>(CCYY-MM-DD/CCYY-MM-DD)</li:possibleProblemSources>
+    <li:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</li:effectiveDates>
+    <li:notes>(multiple lines)</li:notes>
+  </multipathSources>
+  <signalObstructions>
+    <li:possibleProblemSources>(CCYY-MM-DD/CCYY-MM-DD)</li:possibleProblemSources>
+    <li:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</li:effectiveDates>
+    <li:notes>(multiple lines)</li:notes>
+  </signalObstructions>
+  <localEpisodicEvents>
+    <li:date>(CCYY-MM-DDThh</li:date>
+    <li:event>(TREE CLEARING/CONSTRUCTION/etc)</li:event>
+  </localEpisodicEvents>
+  <contactAgency>
+    <contact:agency>Astronomical Institute University of Berne</contact:agency>
+    <contact:preferredAbbreviation>AIUB</contact:preferredAbbreviation>
+    <contact:mailingAddress>Sidlerstrasse 5, CH-3012 Bern</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name>Christian Baumann</contact:name>
+      <contact:telephonePrimary>+41 31 631 38 02</contact:telephonePrimary>
+      <contact:telephoneSecondary>+41 31 631 85 91</contact:telephoneSecondary>
+      <contact:fax>+41 31 631 38 69</contact:fax>
+      <contact:e-mail>christian.baumann@aiub.unibe.ch</contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>Heike Bock</contact:name>
+      <contact:telephonePrimary>+41 31 631 86 02</contact:telephonePrimary>
+      <contact:telephoneSecondary>+41 31 631 85 91</contact:telephoneSecondary>
+      <contact:fax>+41 31 631 38 69</contact:fax>
+      <contact:e-mail>heike.bock@aiub.unibe.ch</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes></contact:notes>
+  </contactAgency>
+  <responsibleAgency>
+    <contact:agency>Astronomical Institute University of Berne</contact:agency>
+    <contact:preferredAbbreviation>AIUB</contact:preferredAbbreviation>
+    <contact:mailingAddress>(multiple lines)</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>(multiple lines)</contact:notes>
+  </responsibleAgency>
+  <moreInformation>
+    <mi:primaryDataCenter>http</mi:primaryDataCenter>
+    <mi:secondaryDataCenter>http</mi:secondaryDataCenter>
+    <mi:urlForMoreInformation>http</mi:urlForMoreInformation>
+    <mi:hardCopyOnFile/>
+    <mi:siteMap>(Y or URL)</mi:siteMap>
+    <mi:siteDiagram>(Y or URL)</mi:siteDiagram>
+    <mi:horizonMask>(Y or URL)</mi:horizonMask>
+    <mi:monumentDescription></mi:monumentDescription>
+    <mi:sitePictures>(Y or URL)</mi:sitePictures>
+    <mi:notes></mi:notes>
+    <mi:antennaGraphicsWithDimensions/>
+    <mi:insertTextGraphicFromAntenna/>
+  </moreInformation>
+</igsSiteLog>

--- a/src/test/resources/sitelog/testData/ZIMJ-radioInterference-withEffectiveDates.xml
+++ b/src/test/resources/sitelog/testData/ZIMJ-radioInterference-withEffectiveDates.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<igsSiteLog xmlns="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004" xmlns:contact="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/contact/2004" xmlns:equip="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004" xmlns:li="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004" xmlns:mi="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004  http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004/igsSiteLog.xsd"><!--Alice Springs Station Log-->
+<!--Version 0.01-->
+<!--Geoscience Australia Geodesy-->
+<!--For More Information regarding XML based Site Logs go to-->
+<!--http://sopac.ucsd.edu/projects/xml-->
+
+  <formInformation>
+    <mi:preparedBy>Christian Baumann (AIUB)</mi:preparedBy>
+    <mi:datePrepared>2013-05-21</mi:datePrepared>
+    <mi:reportType>UPDATE</mi:reportType>
+    <mi:previousLog>zimj_20121007.log</mi:previousLog>
+    <mi:modifiedSections>3.11, 3.12, 4.2, 5., 7.3, 7.4, 8., 11., 13.</mi:modifiedSections>
+  </formInformation>
+  <siteIdentification>
+    <mi:siteName>Zimmerwald GPS87E</mi:siteName>
+    <mi:fourCharacterID>ZIMJ</mi:fourCharacterID>
+    <mi:monumentInscription>GPS87E</mi:monumentInscription>
+    <mi:iersDOMESNumber>14001M006</mi:iersDOMESNumber>
+    <mi:cdpNumber></mi:cdpNumber>
+    <mi:monumentDescription>STEEL MAST</mi:monumentDescription>
+    <mi:heightOfTheMonument></mi:heightOfTheMonument>
+    <mi:monumentFoundation>ROOF of the observatory</mi:monumentFoundation>
+    <mi:foundationDepth></mi:foundationDepth>
+    <mi:markerDescription>Eccentric mount on steel mast (GPS87)</mi:markerDescription>
+    <mi:dateInstalled>1995-01-01</mi:dateInstalled>
+    <mi:geologicCharacteristic>CONGLOMERATE</mi:geologicCharacteristic>
+    <mi:bedrockType>SEDIMENTARY</mi:bedrockType>
+    <mi:bedrockCondition>JOINTED</mi:bedrockCondition>
+    <mi:fractureSpacing></mi:fractureSpacing>
+    <mi:faultZonesNearby></mi:faultZonesNearby>
+    <mi:distance-Activity></mi:distance-Activity>
+    <mi:notes>Morraine Exact date in 1995 not known</mi:notes>
+  </siteIdentification>
+  <siteLocation>
+    <mi:city>Zimmerwald</mi:city>
+    <mi:state>Bern</mi:state>
+    <mi:country>Switzerland</mi:country>
+    <mi:tectonicPlate>Eurasian Plate</mi:tectonicPlate>
+    <approximatePositionITRF>
+      <mi:xCoordinateInMeters>4331294.043</mi:xCoordinateInMeters>
+      <mi:yCoordinateInMeters>567541.982</mi:yCoordinateInMeters>
+      <mi:zCoordinateInMeters>4633135.625</mi:zCoordinateInMeters>
+      <mi:latitude-North>+465237.70</mi:latitude-North>
+      <mi:longitude-East>+0072754.36</mi:longitude-East>
+      <mi:elevation-m_ellips.>954.3</mi:elevation-m_ellips.>
+    </approximatePositionITRF>
+    <mi:notes>ITRF2000, epoch 1997.0</mi:notes>
+  </siteLocation>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.4 Jan 22,1999</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-02-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-04-16</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.5 Mar,18,1999 pl3</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-04-17T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-05-05</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.6 Apr,26,1999 pl1</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-05-06T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-07-05</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.8 Jun,17,1999 pl2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-07-06T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-08-16</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.9 Aug,11,1999 pl2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-08-17T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2000-08-08</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.1 Jun,16,2000</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2000-08-09T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2003-10-08</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.3 Aug,01,2003 p2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2003-10-08T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.3 APR,28,2004 p4</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2003-10-08T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2007-10-30T12:59Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.6.0 Oct,24,2007 ob</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2007-10-30T13:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.6.1 Jan,10,2008</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2008-01-16T10:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2010-10-22T13:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JAVAD TRE_G3TH DELTA</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO+GAL+SBAS</equip:satelliteSystem>
+    <equip:serialNumber>00634</equip:serialNumber>
+    <equip:firmwareVersion>3.2.6 Feb,24,2011</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2011-06-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2013-04-30T16:30Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes>Exact date in 2011 not known</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JAVAD TRE_G3TH DELTA</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO+GAL+SBAS</equip:satelliteSystem>
+    <equip:serialNumber>00634</equip:serialNumber>
+    <equip:firmwareVersion>3.4.9 Apr,18,2013</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2013-04-30T16:32Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssAntenna>
+    <equip:antennaType>JPSREGANT_SD_E1 NONE</equip:antennaType>
+    <equip:serialNumber>RA0059</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0770</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength>Approx. 10</equip:antennaCableLength>
+    <equip:dateInstalled>1999-02-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes> Antenna type listed in this section retro- actively changed from JPSREGANT_SD_E to JPSREGANT_SD_E1 starting with log file zimj_20121007.log. See IGSMAIL-6662 and IGSMAIL-6663 for details.</equip:notes>
+  </gnssAntenna>
+  <gnssAntenna>
+    <equip:antennaType>JAVRINGANT_DM   NONE</equip:antennaType>
+    <equip:serialNumber>00427</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0770</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength></equip:antennaCableLength>
+    <equip:dateInstalled>2011-06-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes>Individual absolute antenna calibration values are available</equip:notes>
+  </gnssAntenna>
+  <frequencyStandard>
+    <equip:standardType>INTERNAL</equip:standardType>
+    <equip:inputFrequency></equip:inputFrequency>
+    <equip:effectiveDates></equip:effectiveDates>
+    <equip:notes></equip:notes>
+  </frequencyStandard>
+  <collocationInformation>
+    <equip:instrumentType>SLR </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1976-01-01 </equip:effectiveDates>
+    <equip:notes>New telescope since 1996  Exact date in 1976 not known</equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>Earth tide gravimeter </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1995-01-01 </equip:effectiveDates>
+    <equip:notes>Swiss Federal Institute of Technology  Geodesy and Geodynamics Lab (GGL)  ETH-Hoenggerberg  CH-8093 Zurich  Exact date in 1995 not known</equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>GPS </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1993-05-01 </equip:effectiveDates>
+    <equip:notes>Official IGS site ZIMM 14001M004  See IGS site log file zimm*.log </equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>GPS/GLONASS </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>2007-11-08</equip:effectiveDates>
+    <equip:notes>Official IGLOS site   ZIM2 14001M008  See IGS site log file zim2*.log </equip:notes>
+  </collocationInformation>
+  <radioInterferences>
+    <li:possibleProblemSources>TV</li:possibleProblemSources>
+    <li:effectiveDates>2012-01-15/2014-01-31</li:effectiveDates>
+    <li:observedDegredation></li:observedDegredation>
+    <li:notes>(multiple lines)</li:notes>
+  </radioInterferences>
+  <multipathSources>
+    <li:possibleProblemSources>(CCYY-MM-DD/CCYY-MM-DD)</li:possibleProblemSources>
+    <li:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</li:effectiveDates>
+    <li:notes>(multiple lines)</li:notes>
+  </multipathSources>
+  <signalObstructions>
+    <li:possibleProblemSources>(CCYY-MM-DD/CCYY-MM-DD)</li:possibleProblemSources>
+    <li:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</li:effectiveDates>
+    <li:notes>(multiple lines)</li:notes>
+  </signalObstructions>
+  <localEpisodicEvents>
+    <li:date>(CCYY-MM-DDThh</li:date>
+    <li:event>(TREE CLEARING/CONSTRUCTION/etc)</li:event>
+  </localEpisodicEvents>
+  <contactAgency>
+    <contact:agency>Astronomical Institute University of Berne</contact:agency>
+    <contact:preferredAbbreviation>AIUB</contact:preferredAbbreviation>
+    <contact:mailingAddress>Sidlerstrasse 5, CH-3012 Bern</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name>Christian Baumann</contact:name>
+      <contact:telephonePrimary>+41 31 631 38 02</contact:telephonePrimary>
+      <contact:telephoneSecondary>+41 31 631 85 91</contact:telephoneSecondary>
+      <contact:fax>+41 31 631 38 69</contact:fax>
+      <contact:e-mail>christian.baumann@aiub.unibe.ch</contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>Heike Bock</contact:name>
+      <contact:telephonePrimary>+41 31 631 86 02</contact:telephonePrimary>
+      <contact:telephoneSecondary>+41 31 631 85 91</contact:telephoneSecondary>
+      <contact:fax>+41 31 631 38 69</contact:fax>
+      <contact:e-mail>heike.bock@aiub.unibe.ch</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes></contact:notes>
+  </contactAgency>
+  <responsibleAgency>
+    <contact:agency>Astronomical Institute University of Berne</contact:agency>
+    <contact:preferredAbbreviation>AIUB</contact:preferredAbbreviation>
+    <contact:mailingAddress>(multiple lines)</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>(multiple lines)</contact:notes>
+  </responsibleAgency>
+  <moreInformation>
+    <mi:primaryDataCenter>http</mi:primaryDataCenter>
+    <mi:secondaryDataCenter>http</mi:secondaryDataCenter>
+    <mi:urlForMoreInformation>http</mi:urlForMoreInformation>
+    <mi:hardCopyOnFile/>
+    <mi:siteMap>(Y or URL)</mi:siteMap>
+    <mi:siteDiagram>(Y or URL)</mi:siteDiagram>
+    <mi:horizonMask>(Y or URL)</mi:horizonMask>
+    <mi:monumentDescription></mi:monumentDescription>
+    <mi:sitePictures>(Y or URL)</mi:sitePictures>
+    <mi:notes></mi:notes>
+    <mi:antennaGraphicsWithDimensions/>
+    <mi:insertTextGraphicFromAntenna/>
+  </moreInformation>
+</igsSiteLog>

--- a/src/test/resources/sitelog/testData/ZIMJ-radioInterference-withEffectiveDatesNoToForm1.xml
+++ b/src/test/resources/sitelog/testData/ZIMJ-radioInterference-withEffectiveDatesNoToForm1.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<igsSiteLog xmlns="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004" xmlns:contact="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/contact/2004" xmlns:equip="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004" xmlns:li="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004" xmlns:mi="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004  http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004/igsSiteLog.xsd"><!--Alice Springs Station Log-->
+<!--Version 0.01-->
+<!--Geoscience Australia Geodesy-->
+<!--For More Information regarding XML based Site Logs go to-->
+<!--http://sopac.ucsd.edu/projects/xml-->
+
+  <formInformation>
+    <mi:preparedBy>Christian Baumann (AIUB)</mi:preparedBy>
+    <mi:datePrepared>2013-05-21</mi:datePrepared>
+    <mi:reportType>UPDATE</mi:reportType>
+    <mi:previousLog>zimj_20121007.log</mi:previousLog>
+    <mi:modifiedSections>3.11, 3.12, 4.2, 5., 7.3, 7.4, 8., 11., 13.</mi:modifiedSections>
+  </formInformation>
+  <siteIdentification>
+    <mi:siteName>Zimmerwald GPS87E</mi:siteName>
+    <mi:fourCharacterID>ZIMJ</mi:fourCharacterID>
+    <mi:monumentInscription>GPS87E</mi:monumentInscription>
+    <mi:iersDOMESNumber>14001M006</mi:iersDOMESNumber>
+    <mi:cdpNumber></mi:cdpNumber>
+    <mi:monumentDescription>STEEL MAST</mi:monumentDescription>
+    <mi:heightOfTheMonument></mi:heightOfTheMonument>
+    <mi:monumentFoundation>ROOF of the observatory</mi:monumentFoundation>
+    <mi:foundationDepth></mi:foundationDepth>
+    <mi:markerDescription>Eccentric mount on steel mast (GPS87)</mi:markerDescription>
+    <mi:dateInstalled>1995-01-01</mi:dateInstalled>
+    <mi:geologicCharacteristic>CONGLOMERATE</mi:geologicCharacteristic>
+    <mi:bedrockType>SEDIMENTARY</mi:bedrockType>
+    <mi:bedrockCondition>JOINTED</mi:bedrockCondition>
+    <mi:fractureSpacing></mi:fractureSpacing>
+    <mi:faultZonesNearby></mi:faultZonesNearby>
+    <mi:distance-Activity></mi:distance-Activity>
+    <mi:notes>Morraine Exact date in 1995 not known</mi:notes>
+  </siteIdentification>
+  <siteLocation>
+    <mi:city>Zimmerwald</mi:city>
+    <mi:state>Bern</mi:state>
+    <mi:country>Switzerland</mi:country>
+    <mi:tectonicPlate>Eurasian Plate</mi:tectonicPlate>
+    <approximatePositionITRF>
+      <mi:xCoordinateInMeters>4331294.043</mi:xCoordinateInMeters>
+      <mi:yCoordinateInMeters>567541.982</mi:yCoordinateInMeters>
+      <mi:zCoordinateInMeters>4633135.625</mi:zCoordinateInMeters>
+      <mi:latitude-North>+465237.70</mi:latitude-North>
+      <mi:longitude-East>+0072754.36</mi:longitude-East>
+      <mi:elevation-m_ellips.>954.3</mi:elevation-m_ellips.>
+    </approximatePositionITRF>
+    <mi:notes>ITRF2000, epoch 1997.0</mi:notes>
+  </siteLocation>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.4 Jan 22,1999</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-02-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-04-16</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.5 Mar,18,1999 pl3</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-04-17T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-05-05</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.6 Apr,26,1999 pl1</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-05-06T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-07-05</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.8 Jun,17,1999 pl2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-07-06T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-08-16</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.9 Aug,11,1999 pl2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-08-17T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2000-08-08</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.1 Jun,16,2000</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2000-08-09T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2003-10-08</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.3 Aug,01,2003 p2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2003-10-08T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.3 APR,28,2004 p4</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2003-10-08T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2007-10-30T12:59Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.6.0 Oct,24,2007 ob</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2007-10-30T13:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.6.1 Jan,10,2008</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2008-01-16T10:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2010-10-22T13:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JAVAD TRE_G3TH DELTA</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO+GAL+SBAS</equip:satelliteSystem>
+    <equip:serialNumber>00634</equip:serialNumber>
+    <equip:firmwareVersion>3.2.6 Feb,24,2011</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2011-06-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2013-04-30T16:30Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes>Exact date in 2011 not known</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JAVAD TRE_G3TH DELTA</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO+GAL+SBAS</equip:satelliteSystem>
+    <equip:serialNumber>00634</equip:serialNumber>
+    <equip:firmwareVersion>3.4.9 Apr,18,2013</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2013-04-30T16:32Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssAntenna>
+    <equip:antennaType>JPSREGANT_SD_E1 NONE</equip:antennaType>
+    <equip:serialNumber>RA0059</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0770</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength>Approx. 10</equip:antennaCableLength>
+    <equip:dateInstalled>1999-02-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes> Antenna type listed in this section retro- actively changed from JPSREGANT_SD_E to JPSREGANT_SD_E1 starting with log file zimj_20121007.log. See IGSMAIL-6662 and IGSMAIL-6663 for details.</equip:notes>
+  </gnssAntenna>
+  <gnssAntenna>
+    <equip:antennaType>JAVRINGANT_DM   NONE</equip:antennaType>
+    <equip:serialNumber>00427</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0770</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength></equip:antennaCableLength>
+    <equip:dateInstalled>2011-06-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes>Individual absolute antenna calibration values are available</equip:notes>
+  </gnssAntenna>
+  <frequencyStandard>
+    <equip:standardType>INTERNAL</equip:standardType>
+    <equip:inputFrequency></equip:inputFrequency>
+    <equip:effectiveDates></equip:effectiveDates>
+    <equip:notes></equip:notes>
+  </frequencyStandard>
+  <collocationInformation>
+    <equip:instrumentType>SLR </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1976-01-01 </equip:effectiveDates>
+    <equip:notes>New telescope since 1996  Exact date in 1976 not known</equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>Earth tide gravimeter </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1995-01-01 </equip:effectiveDates>
+    <equip:notes>Swiss Federal Institute of Technology  Geodesy and Geodynamics Lab (GGL)  ETH-Hoenggerberg  CH-8093 Zurich  Exact date in 1995 not known</equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>GPS </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1993-05-01 </equip:effectiveDates>
+    <equip:notes>Official IGS site ZIMM 14001M004  See IGS site log file zimm*.log </equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>GPS/GLONASS </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>2007-11-08</equip:effectiveDates>
+    <equip:notes>Official IGLOS site   ZIM2 14001M008  See IGS site log file zim2*.log </equip:notes>
+  </collocationInformation>
+  <radioInterferences>
+    <li:possibleProblemSources>TV</li:possibleProblemSources>
+    <li:effectiveDates>2012-01-15/CCYY-MM-DD</li:effectiveDates>
+    <li:observedDegredation></li:observedDegredation>
+    <li:notes>(multiple lines)</li:notes>
+  </radioInterferences>
+  <multipathSources>
+    <li:possibleProblemSources>(CCYY-MM-DD/CCYY-MM-DD)</li:possibleProblemSources>
+    <li:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</li:effectiveDates>
+    <li:notes>(multiple lines)</li:notes>
+  </multipathSources>
+  <signalObstructions>
+    <li:possibleProblemSources>(CCYY-MM-DD/CCYY-MM-DD)</li:possibleProblemSources>
+    <li:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</li:effectiveDates>
+    <li:notes>(multiple lines)</li:notes>
+  </signalObstructions>
+  <localEpisodicEvents>
+    <li:date>(CCYY-MM-DDThh</li:date>
+    <li:event>(TREE CLEARING/CONSTRUCTION/etc)</li:event>
+  </localEpisodicEvents>
+  <contactAgency>
+    <contact:agency>Astronomical Institute University of Berne</contact:agency>
+    <contact:preferredAbbreviation>AIUB</contact:preferredAbbreviation>
+    <contact:mailingAddress>Sidlerstrasse 5, CH-3012 Bern</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name>Christian Baumann</contact:name>
+      <contact:telephonePrimary>+41 31 631 38 02</contact:telephonePrimary>
+      <contact:telephoneSecondary>+41 31 631 85 91</contact:telephoneSecondary>
+      <contact:fax>+41 31 631 38 69</contact:fax>
+      <contact:e-mail>christian.baumann@aiub.unibe.ch</contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>Heike Bock</contact:name>
+      <contact:telephonePrimary>+41 31 631 86 02</contact:telephonePrimary>
+      <contact:telephoneSecondary>+41 31 631 85 91</contact:telephoneSecondary>
+      <contact:fax>+41 31 631 38 69</contact:fax>
+      <contact:e-mail>heike.bock@aiub.unibe.ch</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes></contact:notes>
+  </contactAgency>
+  <responsibleAgency>
+    <contact:agency>Astronomical Institute University of Berne</contact:agency>
+    <contact:preferredAbbreviation>AIUB</contact:preferredAbbreviation>
+    <contact:mailingAddress>(multiple lines)</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>(multiple lines)</contact:notes>
+  </responsibleAgency>
+  <moreInformation>
+    <mi:primaryDataCenter>http</mi:primaryDataCenter>
+    <mi:secondaryDataCenter>http</mi:secondaryDataCenter>
+    <mi:urlForMoreInformation>http</mi:urlForMoreInformation>
+    <mi:hardCopyOnFile/>
+    <mi:siteMap>(Y or URL)</mi:siteMap>
+    <mi:siteDiagram>(Y or URL)</mi:siteDiagram>
+    <mi:horizonMask>(Y or URL)</mi:horizonMask>
+    <mi:monumentDescription></mi:monumentDescription>
+    <mi:sitePictures>(Y or URL)</mi:sitePictures>
+    <mi:notes></mi:notes>
+    <mi:antennaGraphicsWithDimensions/>
+    <mi:insertTextGraphicFromAntenna/>
+  </moreInformation>
+</igsSiteLog>

--- a/src/test/resources/sitelog/testData/ZIMJ-radioInterference-withEffectiveDatesNoToForm2.xml
+++ b/src/test/resources/sitelog/testData/ZIMJ-radioInterference-withEffectiveDatesNoToForm2.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<igsSiteLog xmlns="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004" xmlns:contact="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/contact/2004" xmlns:equip="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004" xmlns:li="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004" xmlns:mi="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004  http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004/igsSiteLog.xsd"><!--Alice Springs Station Log-->
+<!--Version 0.01-->
+<!--Geoscience Australia Geodesy-->
+<!--For More Information regarding XML based Site Logs go to-->
+<!--http://sopac.ucsd.edu/projects/xml-->
+
+  <formInformation>
+    <mi:preparedBy>Christian Baumann (AIUB)</mi:preparedBy>
+    <mi:datePrepared>2013-05-21</mi:datePrepared>
+    <mi:reportType>UPDATE</mi:reportType>
+    <mi:previousLog>zimj_20121007.log</mi:previousLog>
+    <mi:modifiedSections>3.11, 3.12, 4.2, 5., 7.3, 7.4, 8., 11., 13.</mi:modifiedSections>
+  </formInformation>
+  <siteIdentification>
+    <mi:siteName>Zimmerwald GPS87E</mi:siteName>
+    <mi:fourCharacterID>ZIMJ</mi:fourCharacterID>
+    <mi:monumentInscription>GPS87E</mi:monumentInscription>
+    <mi:iersDOMESNumber>14001M006</mi:iersDOMESNumber>
+    <mi:cdpNumber></mi:cdpNumber>
+    <mi:monumentDescription>STEEL MAST</mi:monumentDescription>
+    <mi:heightOfTheMonument></mi:heightOfTheMonument>
+    <mi:monumentFoundation>ROOF of the observatory</mi:monumentFoundation>
+    <mi:foundationDepth></mi:foundationDepth>
+    <mi:markerDescription>Eccentric mount on steel mast (GPS87)</mi:markerDescription>
+    <mi:dateInstalled>1995-01-01</mi:dateInstalled>
+    <mi:geologicCharacteristic>CONGLOMERATE</mi:geologicCharacteristic>
+    <mi:bedrockType>SEDIMENTARY</mi:bedrockType>
+    <mi:bedrockCondition>JOINTED</mi:bedrockCondition>
+    <mi:fractureSpacing></mi:fractureSpacing>
+    <mi:faultZonesNearby></mi:faultZonesNearby>
+    <mi:distance-Activity></mi:distance-Activity>
+    <mi:notes>Morraine Exact date in 1995 not known</mi:notes>
+  </siteIdentification>
+  <siteLocation>
+    <mi:city>Zimmerwald</mi:city>
+    <mi:state>Bern</mi:state>
+    <mi:country>Switzerland</mi:country>
+    <mi:tectonicPlate>Eurasian Plate</mi:tectonicPlate>
+    <approximatePositionITRF>
+      <mi:xCoordinateInMeters>4331294.043</mi:xCoordinateInMeters>
+      <mi:yCoordinateInMeters>567541.982</mi:yCoordinateInMeters>
+      <mi:zCoordinateInMeters>4633135.625</mi:zCoordinateInMeters>
+      <mi:latitude-North>+465237.70</mi:latitude-North>
+      <mi:longitude-East>+0072754.36</mi:longitude-East>
+      <mi:elevation-m_ellips.>954.3</mi:elevation-m_ellips.>
+    </approximatePositionITRF>
+    <mi:notes>ITRF2000, epoch 1997.0</mi:notes>
+  </siteLocation>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.4 Jan 22,1999</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-02-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-04-16</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.5 Mar,18,1999 pl3</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-04-17T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-05-05</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.6 Apr,26,1999 pl1</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-05-06T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-07-05</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.8 Jun,17,1999 pl2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-07-06T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>1999-08-16</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>1.9 Aug,11,1999 pl2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>1999-08-17T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2000-08-08</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.1 Jun,16,2000</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>5</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2000-08-09T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2003-10-08</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.3 Aug,01,2003 p2</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2003-10-08T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.3 APR,28,2004 p4</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2003-10-08T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2007-10-30T12:59Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.6.0 Oct,24,2007 ob</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2007-10-30T13:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JPS LEGACY</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO</equip:satelliteSystem>
+    <equip:serialNumber>MT300342503</equip:serialNumber>
+    <equip:firmwareVersion>2.6.1 Jan,10,2008</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2008-01-16T10:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2010-10-22T13:00Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JAVAD TRE_G3TH DELTA</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO+GAL+SBAS</equip:satelliteSystem>
+    <equip:serialNumber>00634</equip:serialNumber>
+    <equip:firmwareVersion>3.2.6 Feb,24,2011</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2011-06-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved>2013-04-30T16:30Z</equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes>Exact date in 2011 not known</equip:notes>
+  </gnssReceiver>
+  <gnssReceiver>
+    <equip:receiverType>JAVAD TRE_G3TH DELTA</equip:receiverType>
+    <equip:satelliteSystem>GPS+GLO+GAL+SBAS</equip:satelliteSystem>
+    <equip:serialNumber>00634</equip:serialNumber>
+    <equip:firmwareVersion>3.4.9 Apr,18,2013</equip:firmwareVersion>
+    <equip:elevationCutoffSetting>0</equip:elevationCutoffSetting>
+    <equip:dateInstalled>2013-04-30T16:32Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:temperatureStabilization>None</equip:temperatureStabilization>
+    <equip:notes></equip:notes>
+  </gnssReceiver>
+  <gnssAntenna>
+    <equip:antennaType>JPSREGANT_SD_E1 NONE</equip:antennaType>
+    <equip:serialNumber>RA0059</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0770</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength>Approx. 10</equip:antennaCableLength>
+    <equip:dateInstalled>1999-02-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes> Antenna type listed in this section retro- actively changed from JPSREGANT_SD_E to JPSREGANT_SD_E1 starting with log file zimj_20121007.log. See IGSMAIL-6662 and IGSMAIL-6663 for details.</equip:notes>
+  </gnssAntenna>
+  <gnssAntenna>
+    <equip:antennaType>JAVRINGANT_DM   NONE</equip:antennaType>
+    <equip:serialNumber>00427</equip:serialNumber>
+    <equip:antennaReferencePoint>BPA</equip:antennaReferencePoint>
+    <equip:marker-arpUpEcc.>000.0770</equip:marker-arpUpEcc.>
+    <equip:marker-arpNorthEcc.>000.0000</equip:marker-arpNorthEcc.>
+    <equip:marker-arpEastEcc.>000.0000</equip:marker-arpEastEcc.>
+    <equip:alignmentFromTrueNorth>0</equip:alignmentFromTrueNorth>
+    <equip:antennaRadomeType>NONE</equip:antennaRadomeType>
+    <equip:radomeSerialNumber></equip:radomeSerialNumber>
+    <equip:antennaCableType>(vendor &amp; type number)</equip:antennaCableType>
+    <equip:antennaCableLength></equip:antennaCableLength>
+    <equip:dateInstalled>2011-06-03T00:00Z</equip:dateInstalled>
+    <equip:dateRemoved></equip:dateRemoved>
+    <equip:notes>Individual absolute antenna calibration values are available</equip:notes>
+  </gnssAntenna>
+  <frequencyStandard>
+    <equip:standardType>INTERNAL</equip:standardType>
+    <equip:inputFrequency></equip:inputFrequency>
+    <equip:effectiveDates></equip:effectiveDates>
+    <equip:notes></equip:notes>
+  </frequencyStandard>
+  <collocationInformation>
+    <equip:instrumentType>SLR </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1976-01-01 </equip:effectiveDates>
+    <equip:notes>New telescope since 1996  Exact date in 1976 not known</equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>Earth tide gravimeter </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1995-01-01 </equip:effectiveDates>
+    <equip:notes>Swiss Federal Institute of Technology  Geodesy and Geodynamics Lab (GGL)  ETH-Hoenggerberg  CH-8093 Zurich  Exact date in 1995 not known</equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>GPS </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>1993-05-01 </equip:effectiveDates>
+    <equip:notes>Official IGS site ZIMM 14001M004  See IGS site log file zimm*.log </equip:notes>
+  </collocationInformation>
+  <collocationInformation>
+    <equip:instrumentType>GPS/GLONASS </equip:instrumentType>
+    <equip:status>PERMANENT </equip:status>
+    <equip:effectiveDates>2007-11-08</equip:effectiveDates>
+    <equip:notes>Official IGLOS site   ZIM2 14001M008  See IGS site log file zim2*.log </equip:notes>
+  </collocationInformation>
+  <radioInterferences>
+    <li:possibleProblemSources>TV</li:possibleProblemSources>
+    <li:effectiveDates>2012-01-15</li:effectiveDates>
+    <li:observedDegredation></li:observedDegredation>
+    <li:notes>(multiple lines)</li:notes>
+  </radioInterferences>
+  <multipathSources>
+    <li:possibleProblemSources>(CCYY-MM-DD/CCYY-MM-DD)</li:possibleProblemSources>
+    <li:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</li:effectiveDates>
+    <li:notes>(multiple lines)</li:notes>
+  </multipathSources>
+  <signalObstructions>
+    <li:possibleProblemSources>(CCYY-MM-DD/CCYY-MM-DD)</li:possibleProblemSources>
+    <li:effectiveDates>(CCYY-MM-DD/CCYY-MM-DD)</li:effectiveDates>
+    <li:notes>(multiple lines)</li:notes>
+  </signalObstructions>
+  <localEpisodicEvents>
+    <li:date>(CCYY-MM-DDThh</li:date>
+    <li:event>(TREE CLEARING/CONSTRUCTION/etc)</li:event>
+  </localEpisodicEvents>
+  <contactAgency>
+    <contact:agency>Astronomical Institute University of Berne</contact:agency>
+    <contact:preferredAbbreviation>AIUB</contact:preferredAbbreviation>
+    <contact:mailingAddress>Sidlerstrasse 5, CH-3012 Bern</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name>Christian Baumann</contact:name>
+      <contact:telephonePrimary>+41 31 631 38 02</contact:telephonePrimary>
+      <contact:telephoneSecondary>+41 31 631 85 91</contact:telephoneSecondary>
+      <contact:fax>+41 31 631 38 69</contact:fax>
+      <contact:e-mail>christian.baumann@aiub.unibe.ch</contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name>Heike Bock</contact:name>
+      <contact:telephonePrimary>+41 31 631 86 02</contact:telephonePrimary>
+      <contact:telephoneSecondary>+41 31 631 85 91</contact:telephoneSecondary>
+      <contact:fax>+41 31 631 38 69</contact:fax>
+      <contact:e-mail>heike.bock@aiub.unibe.ch</contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes></contact:notes>
+  </contactAgency>
+  <responsibleAgency>
+    <contact:agency>Astronomical Institute University of Berne</contact:agency>
+    <contact:preferredAbbreviation>AIUB</contact:preferredAbbreviation>
+    <contact:mailingAddress>(multiple lines)</contact:mailingAddress>
+    <contact:primaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:primaryContact>
+    <contact:secondaryContact>
+      <contact:name></contact:name>
+      <contact:telephonePrimary></contact:telephonePrimary>
+      <contact:telephoneSecondary></contact:telephoneSecondary>
+      <contact:fax></contact:fax>
+      <contact:e-mail></contact:e-mail>
+    </contact:secondaryContact>
+    <contact:notes>(multiple lines)</contact:notes>
+  </responsibleAgency>
+  <moreInformation>
+    <mi:primaryDataCenter>http</mi:primaryDataCenter>
+    <mi:secondaryDataCenter>http</mi:secondaryDataCenter>
+    <mi:urlForMoreInformation>http</mi:urlForMoreInformation>
+    <mi:hardCopyOnFile/>
+    <mi:siteMap>(Y or URL)</mi:siteMap>
+    <mi:siteDiagram>(Y or URL)</mi:siteDiagram>
+    <mi:horizonMask>(Y or URL)</mi:horizonMask>
+    <mi:monumentDescription></mi:monumentDescription>
+    <mi:sitePictures>(Y or URL)</mi:sitePictures>
+    <mi:notes></mi:notes>
+    <mi:antennaGraphicsWithDimensions/>
+    <mi:insertTextGraphicFromAntenna/>
+  </moreInformation>
+</igsSiteLog>


### PR DESCRIPTION
Make sure that Sopac EffectiveDate is translated properly to GeodesyML:
* If null then geodesyml's sitelog.radiointerference.validtime is null
* if has both a from and to date then geodesyml's sitelog.radiointerference.validtime has same values in beginPosition and endPosition
* If has one or the other of from and to, then geodesyml's sitelog.radiointerference.validtime has a corresponding null for the beginPosition or endPosition

This change:

* Also add back in the Dozer tests into the maven testing