### PR TITLE
Turn on direct field access web data binding

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/port/adapter/rest/GnssReceiverEndpoint.java
+++ b/src/main/java/au/gov/ga/geodesy/port/adapter/rest/GnssReceiverEndpoint.java
@@ -10,6 +10,9 @@ import org.springframework.hateoas.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -31,6 +34,11 @@ public class GnssReceiverEndpoint {
 
     @Autowired
     private PagedResourcesAssembler<GnssReceiver> assembler;
+
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        binder.initDirectFieldAccess();
+    }
 
     /**
      * Find GnssReceivers by example.


### PR DESCRIPTION
This fixes the currently failing GnssReceiverEndpointTest. Without direct field access, request parameter binding cannot access immutable fields of GnssReceiver.