### PR TITLE
Self links

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/port/adapter/rest/GnssReceiverEndpoint.java
+++ b/src/main/java/au/gov/ga/geodesy/port/adapter/rest/GnssReceiverEndpoint.java
@@ -3,16 +3,17 @@ package au.gov.ga.geodesy.port.adapter.rest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.PersistentEntityResourceAssembler;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.ResourceAssembler;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.InitBinder;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -50,6 +51,7 @@ public class GnssReceiverEndpoint {
 
     public ResponseEntity<PagedResources<Resource<GnssReceiver>>> findByExample(
             GnssReceiver receiver,
+            PersistentEntityResourceAssembler entityAssembler,
             Pageable pageRequest) {
 
         BooleanBuilder builder = new BooleanBuilder();
@@ -62,9 +64,12 @@ public class GnssReceiverEndpoint {
             builder.and(qReceiver.type.eq(receiver.getType()));
         }
         Predicate receiverPredicate = builder.getValue();
-
         Page<GnssReceiver> page = receivers.findAll(receiverPredicate, pageRequest);
-        PagedResources<Resource<GnssReceiver>> paged = assembler.toResource(page);
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        PagedResources<Resource<GnssReceiver>> paged = assembler.toResource(page,
+            (ResourceAssembler) entityAssembler);
+
         return new ResponseEntity<>(paged, new HttpHeaders(), HttpStatus.OK);
     }
 }

--- a/src/main/java/au/gov/ga/geodesy/port/adapter/rest/SetupEndpoint.java
+++ b/src/main/java/au/gov/ga/geodesy/port/adapter/rest/SetupEndpoint.java
@@ -13,6 +13,7 @@ import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.ResourceAssembler;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -51,6 +52,7 @@ public class SetupEndpoint {
             @RequestParam(required = false) String effectiveFrom,
             @RequestParam(required = false) String effectiveTo,
             @RequestParam(defaultValue = "uuuu-MM-dd") String timeFormat,
+            PersistentEntityResourceAssembler entityAssembler,
             Pageable pageRequest) {
 
         Page<Setup> page = null;
@@ -64,7 +66,10 @@ public class SetupEndpoint {
         } else {
             page = new PageImpl<Setup>(new ArrayList<Setup>());
         }
-        PagedResources<Resource<Setup>> paged = assembler.toResource(page);
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        PagedResources<Resource<Setup>> paged = assembler.toResource(page,
+            (ResourceAssembler) entityAssembler);
+
         return new ResponseEntity<>(paged, new HttpHeaders(), HttpStatus.OK);
     }
 

--- a/src/test/java/au/gov/ga/geodesy/port/adapter/rest/GnssReceiverEndpointTest.java
+++ b/src/test/java/au/gov/ga/geodesy/port/adapter/rest/GnssReceiverEndpointTest.java
@@ -37,6 +37,7 @@ public class GnssReceiverEndpointTest extends RestTest {
             .andExpect(status().isOk())
             .andDo(print)
             .andExpect(jsonPath("$.page.totalElements").value(1))
-            .andExpect(jsonPath("$._embedded.gnssReceivers[0].type").value("TRIMBLE NETRS"));
+            .andExpect(jsonPath("$._embedded.gnssReceivers[0].type").value("TRIMBLE NETRS"))
+            .andExpect(jsonPath("$._embedded.gnssReceivers[0]._links.self").isNotEmpty());
     }
 }

--- a/src/test/java/au/gov/ga/geodesy/port/adapter/rest/SetupEndpointTest.java
+++ b/src/test/java/au/gov/ga/geodesy/port/adapter/rest/SetupEndpointTest.java
@@ -32,7 +32,8 @@ public class SetupEndpointTest extends RestTest {
     @Rollback(false)
     public void testFindCurrentByFourCharacterId() throws Exception {
         mvc.perform(get("/setups/search/findCurrentByFourCharacterId?id=ALIC"))
-            .andExpect(status().isOk());
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._links.self").isNotEmpty());
     }
 
     @Test(dependsOnMethods = {"upload"})
@@ -42,7 +43,8 @@ public class SetupEndpointTest extends RestTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.page.totalElements").value(3))
             .andExpect(jsonPath("$._embedded.setups[0].effectivePeriod.from").value("2011-07-20T00:00:00Z"))
-            .andExpect(jsonPath("$._embedded.setups[0].effectivePeriod.to").value("2013-03-08T00:00:00Z"));
+            .andExpect(jsonPath("$._embedded.setups[0].effectivePeriod.to").value("2013-03-08T00:00:00Z"))
+            .andExpect(jsonPath("$._embedded.setups[0]._links.self").isNotEmpty());
     }
 
     @Test(dependsOnMethods = {"upload"})
@@ -53,6 +55,7 @@ public class SetupEndpointTest extends RestTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.page.totalElements").value(expectedTotalElements))
             .andExpect(jsonPath("$._embedded.setups[0].effectivePeriod.from").value("1994-05-15T00:00:00Z"))
+            .andExpect(jsonPath("$._embedded.setups[0]._links.self").isNotEmpty())
             .andExpect(jsonPath("$._embedded.setups[" + (expectedTotalElements - 1) + "].effectivePeriod.to").value(nullValue()));
     }
 }


### PR DESCRIPTION
By default, spring data rest generates self links for all search results. In case of custom queries, we need to use a specific assembler to ensure that the self links are generated.