### PR TITLE
Add mvn profile for running liquibase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -590,6 +590,21 @@
     </build>
     <profiles>
         <profile>
+            <id>liquibase</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.liquibase</groupId>
+                        <artifactId>liquibase-maven-plugin</artifactId>
+                        <version>${liquibase.version}</version>
+                        <configuration>
+                            <propertyFile>src/main/resources/liquibase-postgres-reference.properties</propertyFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>db-diff</id>
             <build>
                 <defaultGoal>process-test-resources</defaultGoal>

--- a/src/main/resources/liquibase-postgres-reference.properties
+++ b/src/main/resources/liquibase-postgres-reference.properties
@@ -1,0 +1,3 @@
+url=jdbc:postgresql://localhost/geodesydb
+username=geodesy
+password=geodesypw


### PR DESCRIPTION
Running `mvn -Pliquibase liquibase:dropAll` will drop all objects in
your reference database, which is the one that integration tests
(i.e., hibernate) run against.