### PR TITLE
Remove redundant cors setup

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/support/spring/GeodesyRestMvcConfig.java
+++ b/src/main/java/au/gov/ga/geodesy/support/spring/GeodesyRestMvcConfig.java
@@ -38,10 +38,4 @@ public class GeodesyRestMvcConfig extends WebMvcConfigurerAdapter {
         super.configureMessageConverters(converters);
         converters.add(mappingJackson2HttpMessageConverter());
     }
-
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        // TODO - Consider if we should restrict the allowed Origins to GA and AWS
-        registry.addMapping("/**").allowedOrigins("*").allowedMethods("PUT", "DELETE", "POST", "GET");
-    }
 }


### PR DESCRIPTION
CORS is setup for all endpoints in geodesy-web-services/src/main/webapp/WEB-INF/web.xml.