### PR TITLE
rename sitelog_responsible_party column name

### DIFF
--- a/src/main/resources/db/geodesy-database-changelog.xml
+++ b/src/main/resources/db/geodesy-database-changelog.xml
@@ -37,6 +37,5 @@
 <include file="db/creante-new-responsible-party-tables.xml"/>
 <include file="db/migrate-site-responsible-party-data-to-new-table.sql"/>
 <include file="db/add-comments-to-new-responsible-party-tables.xml"/>
-<!-- TODO (LB): non-null violation, re-implement using renameColumn? -->
-<!-- <include file="db/rename&#45;responsible&#45;role&#45;column.xml"/> -->
+<include file="db/rename-responsible-party-column-name.sql"/>
 </databaseChangeLog>

--- a/src/main/resources/db/rename-responsible-party-column-name.sql
+++ b/src/main/resources/db/rename-responsible-party-column-name.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset HongJin:1478571328
+
+
+alter table sitelog_responsible_party rename column responsible_role to responsible_role_id;
+
+ALTER TABLE sitelog_responsible_party RENAME CONSTRAINT "fk_sitelog_responsible_party_responsiblerole" TO "fk_sitelog_responsible_party_responsible_roleid";


### PR DESCRIPTION
when rename a table column, Liquibase converted into several separate commands - create column, drop column, add fk, drop fk.  It has caused null value error when run it, because referenced column was not there any more. It could be a Liquibase bug. To prevent it happen again, I have to submit the changes as sql file rather than using the XML file generated by Liquibase.

