### PR TITLE
Run a clean database when running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <encoding>UTF-8</encoding>
         <skip.system.tests>true</skip.system.tests>
         <snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>
+        <skip.createDb>false</skip.createDb>
     </properties>
     <repositories>
         <repository>
@@ -576,10 +577,28 @@
                             <ports>
                                 <port>5433:5432</port>
                             </ports>
+                            <wait>
+                                <!-- TODO: implementing polling -->
+                                <time>10000</time>
+                            </wait>
                         </run>
                     </image>
                  </images>
               </configuration>
+              <executions>
+                  <execution>
+                      <id>start-db</id>
+                      <phase>process-test-resources</phase>
+                      <goals>
+                          <goal>stop</goal>
+                          <goal>build</goal>
+                          <goal>start</goal>
+                      </goals>
+                      <configuration>
+                          <skip>${skip.createDb}</skip>
+                      </configuration>
+                  </execution>
+              </executions>
             </plugin>
         </plugins>
     </build>

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -4,8 +4,6 @@
 # A local installation of maven prefers to run the global installation, if available.
 sudo rm /etc/mavenrc
 
-mvn --settings ./travis/maven-settings.xml docker:build docker:run
-
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     mvn --settings ./travis/maven-settings.xml deploy
     mvn --settings ./travis/maven-settings.xml -Psite site-deploy


### PR DESCRIPTION
This ensures that things just work. Once people get the hang of things,
they can control this behaviour using maven property `skip.createDb`.